### PR TITLE
Added a scanner for file format "magic markers."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(marker_scanner LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(marker_scan
+    src/main.cpp
+)
+
+target_compile_options(marker_scan PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+)
+
+find_package(Threads REQUIRED)
+target_link_libraries(marker_scan PRIVATE Threads::Threads)

--- a/MARKERS.md
+++ b/MARKERS.md
@@ -7,33 +7,32 @@ literal ASCII bytes (e.g. `TREE` matches the four bytes `54 52 45 45`).
 
 ## HDF5 file format markers
 
-- `HDF5_SIGNATURE` = `89 48 44 46 0D 0A 1A 0A`
-- `TREE`
-- `BTHD`
-- `BTIN`
-- `BTLF`
-- `SNOD`
-- `HEAP`
-- `GCOL`
-- `FRHP`
-- `FHDB`
-- `FHIB`
-- `FSHD`
-- `FSSE`
-- `SMTB`
-- `SMLI`
-- `OHDR`
-- `OCHK`
-- `FAHD`
-- `FADB`
-- `EAHD`
-- `EAIB`
-- `EASB`
-- `EADB`
+- `HDF5_SIGNATURE` = `89 48 44 46 0D 0A 1A 0A` - HDF5 file signature
+- `TREE` - Version 1 B-tree node
+- `BTHD` - Version 2 B-tree header
+- `BTIN` - Version 2 B-tree internal node
+- `BTLF` - Version 2 B-tree leaf node
+- `SNOD` - Symbol table node
+- `HEAP` - Local heap
+- `GCOL` - Global heap collection
+- `FRHP` - Fractal heap header
+- `FHDB` - Fractal heap direct block
+- `FHIB` - Fractal heap indirect block
+- `FSHD` - Free-space manager header
+- `FSSE` - Free-space section information
+- `SMTB` - Shared Object Header Message table
+- `SMLI` - Shared message record list
+- `OHDR` - Version 2 object header
+- `OCHK` - Version 2 object header continuation block
+- `FAHD` - Fixed Array header
+- `FADB` - Fixed Array data block
+- `EAHD` - Extensible Array header
+- `EAIB` - Extensible Array index block
+- `EASB` - Extensible Array secondary block
+- `EADB` - Extensible Array data block
 
 ## Onion revision-history markers
 
-- `OHDH`
-- `OWHR`
-- `ORRS`
-
+- `OHDH` - Onion History Data Header
+- `OWHR` - Onion Whole-History Record
+- `ORRS` - Onion Revision Record Signature

--- a/MARKERS.md
+++ b/MARKERS.md
@@ -2,6 +2,8 @@
 
 The `marker_scan` tool uses the concrete on-disk markers explicitly defined in the [HDF5 file format specification](https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t4.html), as well as the markers defined in the [Onion revision-history format](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/Onion_VFD_RFC_211122.pdf).
 
+> Notice that there are multiple versions of the HDF5 file format specification, usually released in conjunction with major HDF5 library releases, and the set of markers grew over time. For example, the version 1 object header does not have marker, and chunk indexes like single chunk and implicit do not have markers. Depending on its modification history, an HDF5 file may contain a subset of the markers listed below. The `marker_scan` tool will report all markers it finds, regardless of the version of the HDF5 file format specification they were introduced in.
+
 Unless noted otherwise, each 4-character marker matches its own name spelled out as
 literal ASCII bytes (e.g. `TREE` matches the four bytes `54 52 45 45`).
 

--- a/MARKERS.md
+++ b/MARKERS.md
@@ -1,0 +1,39 @@
+# Marker List
+
+The `marker_scan` tool uses the concrete on-disk markers explicitly defined in the [HDF5 file format specification](https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t4.html), as well as the markers defined in the [Onion revision-history format](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/Onion_VFD_RFC_211122.pdf).
+
+Unless noted otherwise, each 4-character marker matches its own name spelled out as
+literal ASCII bytes (e.g. `TREE` matches the four bytes `54 52 45 45`).
+
+## HDF5 file format markers
+
+- `HDF5_SIGNATURE` = `89 48 44 46 0D 0A 1A 0A`
+- `TREE`
+- `BTHD`
+- `BTIN`
+- `BTLF`
+- `SNOD`
+- `HEAP`
+- `GCOL`
+- `FRHP`
+- `FHDB`
+- `FHIB`
+- `FSHD`
+- `FSSE`
+- `SMTB`
+- `SMLI`
+- `OHDR`
+- `OCHK`
+- `FAHD`
+- `FADB`
+- `EAHD`
+- `EAIB`
+- `EASB`
+- `EADB`
+
+## Onion revision-history markers
+
+- `OHDH`
+- `OWHR`
+- `ORRS`
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The goal is to describe HDF5 on-disk structures as executable binary format defi
 
 This repository is a work in progress. The current pickles focus on core HDF5 metadata structures, including the superblock, B-trees, object headers, and related messages.
 
-## Repository Layout
+## Repository Layout - Pickles
 
 - [`pickles/common.pk`](pickles/common.pk): shared helpers and common definitions
 - [`pickles/superblock.pk`](pickles/superblock.pk): HDF5 superblock definitions
@@ -15,6 +15,50 @@ This repository is a work in progress. The current pickles focus on core HDF5 me
 - [`pickles/messages.pk`](pickles/messages.pk): object header message definitions
 - [`pickles/lookup3.pk`](pickles/lookup3.pk): implementation of the lookup3 hash function used for checksums
 - [`pickles/construct.pk`](pickles/construct.pk): helpers for constructing version 2 metadata in memory
+
+## Marker Scanner
+
+`marker_scan` is a multithreaded file scanner for the concrete on-disk markers defined in the [HDF5 file format specification](https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t4.html) and the [Onion file format](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/Onion_VFD_RFC_211122.pdf). It can be used to quickly identify the locations of these markers in large files, which can be useful for debugging, data recovery, or understanding file structure.
+
+Build:
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+Usage:
+
+```bash
+# List all known markers
+build/marker_scan --list-markers
+
+# Scan a file with the default thread count
+build/marker_scan path/to/file.h5
+
+# Scan with an explicit thread count (-j is a synonym for --threads)
+build/marker_scan --threads 8 path/to/file.h5.onion
+build/marker_scan -j 8 path/to/file.h5.onion
+
+# Restrict the scan (and listing) to one group of markers
+build/marker_scan --group HDF5 path/to/file.h5
+build/marker_scan --group Onion --list-markers path/to/file.h5.onion
+
+# Show usage
+build/marker_scan --help
+```
+
+The scanner prints one line per detected marker with the marker name and its file offset in both
+hexadecimal and decimal. Progress is reported on stderr when scanning in a terminal.
+
+For example, scanning the sample file `file.h5` in this repository produces the following output:
+
+```text
+HDF5_SIGNATURE  0x0000000000000000 (0)                      
+OHDR            0x0000000000000030 (48)
+OHDR            0x00000000000000C3 (195)
+TREE            0x00000000000001DF (479)
+```
 
 ## Quick Tutorial
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ This repository is a work in progress. The current pickles focus on core HDF5 me
 
 ## Marker Scanner
 
-`marker_scan` is a multithreaded file scanner for the concrete on-disk markers defined in the [HDF5 file format specification](https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t4.html) and the [Onion file format](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/Onion_VFD_RFC_211122.pdf). It can be used to quickly identify the locations of these markers in large files, which can be useful for debugging, data recovery, or understanding file structure.
+`marker_scan` is a multithreaded file scanner for the concrete on-disk markers defined in the [HDF5 file format specification](https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t4.html) and the [Onion file format](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/Onion_VFD_RFC_211122.pdf). See also the [MARKERS.md](MARKERS.md) file for a complete list of known markers.
+
+`marker_scan` can be used to quickly identify the locations of these markers in large files, which can be useful for debugging, data recovery, or understanding file structure.
 
 Build:
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,525 @@
+/* main.cpp - File format marker scanner.  */
+
+/* Copyright (C) 2026 The HDF Group.  */
+
+/* This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fcntl.h>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+struct Marker {
+    std::string name;
+    std::string group;
+    std::vector<std::uint8_t> bytes;
+};
+
+struct Match {
+    std::uint64_t offset;
+    std::string marker_name;
+};
+
+struct Options {
+    std::optional<std::string> file_path;
+    std::optional<std::size_t> thread_count;
+    std::optional<std::string> group_filter;
+    bool list_markers = false;
+    bool help = false;
+};
+
+// Each block is read in one pread call to bound per-thread memory usage.
+// 8 MiB is a reasonable unit for sequential I/O on modern hardware.
+constexpr std::size_t kScanBlockSize = 8ULL * 1024ULL * 1024ULL;
+
+// Chunks smaller than this don't benefit meaningfully from additional threads.
+constexpr std::size_t kMinChunkSize = 1ULL * 1024ULL * 1024ULL;
+
+// Thrown for command-line mistakes so the caller can print usage alongside the
+// error message.  Other std::runtime_errors are I/O or logic errors where the
+// usage text adds no value.
+class UsageError : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+class FileDescriptor {
+  public:
+    explicit FileDescriptor(int fd)
+        : fd_(fd) {
+    }
+
+    ~FileDescriptor() {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    FileDescriptor(const FileDescriptor &) = delete;
+    FileDescriptor &operator=(const FileDescriptor &) = delete;
+
+    int get() const {
+        return fd_;
+    }
+
+  private:
+    int fd_;
+};
+
+std::vector<Marker> build_markers() {
+    return {
+        {"HDF5_SIGNATURE", "HDF5", {0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a}},
+        {"TREE", "HDF5", {'T', 'R', 'E', 'E'}},
+        {"BTHD", "HDF5", {'B', 'T', 'H', 'D'}},
+        {"BTIN", "HDF5", {'B', 'T', 'I', 'N'}},
+        {"BTLF", "HDF5", {'B', 'T', 'L', 'F'}},
+        {"SNOD", "HDF5", {'S', 'N', 'O', 'D'}},
+        {"HEAP", "HDF5", {'H', 'E', 'A', 'P'}},
+        {"GCOL", "HDF5", {'G', 'C', 'O', 'L'}},
+        {"FRHP", "HDF5", {'F', 'R', 'H', 'P'}},
+        {"FHDB", "HDF5", {'F', 'H', 'D', 'B'}},
+        {"FHIB", "HDF5", {'F', 'H', 'I', 'B'}},
+        {"FSHD", "HDF5", {'F', 'S', 'H', 'D'}},
+        {"FSSE", "HDF5", {'F', 'S', 'S', 'E'}},
+        {"SMTB", "HDF5", {'S', 'M', 'T', 'B'}},
+        {"SMLI", "HDF5", {'S', 'M', 'L', 'I'}},
+        {"OHDR", "HDF5", {'O', 'H', 'D', 'R'}},
+        {"OCHK", "HDF5", {'O', 'C', 'H', 'K'}},
+        {"FAHD", "HDF5", {'F', 'A', 'H', 'D'}},
+        {"FADB", "HDF5", {'F', 'A', 'D', 'B'}},
+        {"EAHD", "HDF5", {'E', 'A', 'H', 'D'}},
+        {"EAIB", "HDF5", {'E', 'A', 'I', 'B'}},
+        {"EASB", "HDF5", {'E', 'A', 'S', 'B'}},
+        {"EADB", "HDF5", {'E', 'A', 'D', 'B'}},
+        {"OHDH", "Onion", {'O', 'H', 'D', 'H'}},
+        {"OWHR", "Onion", {'O', 'W', 'H', 'R'}},
+        {"ORRS", "Onion", {'O', 'R', 'R', 'S'}},
+    };
+}
+
+const std::vector<Marker> &markers() {
+    static const std::vector<Marker> all_markers = build_markers();
+    return all_markers;
+}
+
+std::array<std::vector<std::size_t>, 256> build_buckets() {
+    std::array<std::vector<std::size_t>, 256> buckets;
+
+    for (std::size_t i = 0; i < markers().size(); ++i) {
+        const auto first_byte = static_cast<unsigned char>(markers()[i].bytes.front());
+        buckets[first_byte].push_back(i);
+    }
+
+    return buckets;
+}
+
+const std::array<std::vector<std::size_t>, 256> &marker_buckets() {
+    static const auto buckets = build_buckets();
+    return buckets;
+}
+
+std::size_t max_marker_length() {
+    static const std::size_t max_len = []() {
+        std::size_t len = 0;
+        for (const auto &marker : markers()) {
+            len = std::max(len, marker.bytes.size());
+        }
+        return len;
+    }();
+    return max_len;
+}
+
+std::size_t max_marker_name_width() {
+    static const std::size_t width = []() {
+        std::size_t w = 0;
+        for (const auto &marker : markers()) {
+            w = std::max(w, marker.name.size());
+        }
+        return w;
+    }();
+    return width;
+}
+
+std::vector<std::string> known_groups() {
+    std::vector<std::string> groups;
+    for (const auto &marker : markers()) {
+        if (std::find(groups.begin(), groups.end(), marker.group) == groups.end()) {
+            groups.push_back(marker.group);
+        }
+    }
+    return groups;
+}
+
+void print_usage(std::ostream &out, const char *argv0) {
+    out << "Usage:\n"
+        << "  " << argv0 << " --list-markers [FILE]\n"
+        << "  " << argv0 << " [--threads/-j N] [--group GROUP] FILE\n"
+        << "  " << argv0 << " --help\n"
+        << "\n"
+        << "Groups: ";
+    const auto groups = known_groups();
+    for (std::size_t i = 0; i < groups.size(); ++i) {
+        if (i != 0) {
+            out << ", ";
+        }
+        out << groups[i];
+    }
+    out << '\n';
+}
+
+std::string format_errno(const std::string &context) {
+    std::ostringstream oss;
+    oss << context << ": " << std::strerror(errno);
+    return oss.str();
+}
+
+Options parse_options(int argc, char **argv) {
+    Options options;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+
+        if (arg == "--help" || arg == "-h") {
+            options.help = true;
+            continue;
+        }
+
+        if (arg == "--list-markers") {
+            options.list_markers = true;
+            continue;
+        }
+
+        if (arg == "--threads" || arg == "-j") {
+            if (i + 1 >= argc) {
+                throw UsageError("missing value for --threads");
+            }
+
+            const std::string value = argv[++i];
+            std::size_t parsed = 0;
+
+            try {
+                parsed = std::stoull(value);
+            }
+            catch (const std::exception &) {
+                throw UsageError("invalid thread count: " + value);
+            }
+
+            if (parsed == 0) {
+                throw UsageError("thread count must be greater than zero");
+            }
+
+            options.thread_count = parsed;
+            continue;
+        }
+
+        if (arg == "--group") {
+            if (i + 1 >= argc) {
+                throw UsageError("missing value for --group");
+            }
+            options.group_filter = argv[++i];
+            continue;
+        }
+
+        if (options.file_path.has_value()) {
+            throw UsageError("multiple input files were provided");
+        }
+
+        options.file_path = arg;
+    }
+
+    if (!options.help && !options.list_markers && !options.file_path.has_value()) {
+        throw UsageError("an input file is required unless --list-markers is used");
+    }
+
+    return options;
+}
+
+std::string bytes_to_hex(const std::vector<std::uint8_t> &bytes) {
+    std::ostringstream oss;
+    oss << std::hex << std::uppercase << std::setfill('0');
+
+    for (std::size_t i = 0; i < bytes.size(); ++i) {
+        if (i != 0) {
+            oss << ' ';
+        }
+        oss << std::setw(2) << static_cast<unsigned int>(bytes[i]);
+    }
+
+    return oss.str();
+}
+
+void list_markers(std::ostream &out, const std::optional<std::string> &group_filter) {
+    out << "Markers defined in the HDF5 and Onion formats:\n\n";
+
+    std::string current_group;
+    for (const auto &marker : markers()) {
+        if (group_filter.has_value() && marker.group != *group_filter) {
+            continue;
+        }
+
+        if (marker.group != current_group) {
+            current_group = marker.group;
+            out << current_group << ":\n";
+        }
+
+        out << "  " << marker.name;
+
+        const bool has_non_ascii = std::any_of(marker.bytes.begin(), marker.bytes.end(),
+            [](std::uint8_t b) { return b < 0x20 || b > 0x7e; });
+        if (has_non_ascii) {
+            out << " = " << bytes_to_hex(marker.bytes);
+        }
+
+        out << '\n';
+    }
+}
+
+void pread_all(int fd, std::uint8_t *buffer, std::size_t size, std::uint64_t offset) {
+    std::size_t total_read = 0;
+
+    while (total_read < size) {
+        const auto file_offset = static_cast<off_t>(offset + total_read);
+        const ssize_t bytes_read = ::pread(fd, buffer + total_read, size - total_read, file_offset);
+
+        if (bytes_read < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            throw std::runtime_error(format_errno("pread failed"));
+        }
+
+        if (bytes_read == 0) {
+            throw std::runtime_error("unexpected end of file while scanning");
+        }
+
+        total_read += static_cast<std::size_t>(bytes_read);
+    }
+}
+
+std::size_t choose_thread_count(std::uint64_t file_size, std::optional<std::size_t> requested) {
+    std::size_t thread_count = requested.value_or(std::max<std::size_t>(1, std::thread::hardware_concurrency()));
+
+    if (file_size == 0) {
+        return 1;
+    }
+
+    const std::size_t max_useful_threads =
+        std::max<std::size_t>(1, (file_size + kMinChunkSize - 1) / kMinChunkSize);
+
+    return std::max<std::size_t>(1, std::min(thread_count, max_useful_threads));
+}
+
+std::vector<Match> scan_range(int fd, std::uint64_t file_size, std::uint64_t start, std::uint64_t end,
+                               const std::optional<std::string> &group_filter,
+                               std::atomic<std::uint64_t> &bytes_scanned) {
+    std::vector<Match> matches;
+
+    if (start >= end) {
+        return matches;
+    }
+
+    const std::size_t overlap = max_marker_length() - 1;
+    std::vector<std::uint8_t> buffer;
+
+    for (std::uint64_t block_start = start; block_start < end; block_start += kScanBlockSize) {
+        const std::uint64_t block_end = std::min<std::uint64_t>(end, block_start + kScanBlockSize);
+        const std::uint64_t read_end = std::min<std::uint64_t>(file_size, block_end + overlap);
+        const std::size_t bytes_to_read = static_cast<std::size_t>(read_end - block_start);
+        const std::size_t owned_bytes = static_cast<std::size_t>(block_end - block_start);
+
+        buffer.resize(bytes_to_read);
+        pread_all(fd, buffer.data(), buffer.size(), block_start);
+
+        for (std::size_t i = 0; i < owned_bytes; ++i) {
+            const auto &candidate_markers = marker_buckets()[buffer[i]];
+
+            for (const std::size_t marker_index : candidate_markers) {
+                const auto &marker = markers()[marker_index];
+
+                if (group_filter.has_value() && marker.group != *group_filter) {
+                    continue;
+                }
+
+                if (i + marker.bytes.size() > buffer.size()) {
+                    continue;
+                }
+
+                if (std::memcmp(buffer.data() + i, marker.bytes.data(), marker.bytes.size()) == 0) {
+                    matches.push_back(Match{block_start + i, marker.name});
+                }
+            }
+        }
+
+        bytes_scanned.fetch_add(owned_bytes, std::memory_order_relaxed);
+    }
+
+    return matches;
+}
+
+void print_matches(const std::vector<Match> &matches, std::ostream &out) {
+    const std::size_t col_width = max_marker_name_width();
+    for (const auto &match : matches) {
+        out << std::left << std::setfill(' ') << std::setw(static_cast<int>(col_width))
+            << match.marker_name
+            << "  0x" << std::right << std::setfill('0') << std::setw(16)
+            << std::hex << std::uppercase << match.offset << std::dec << std::setfill(' ')
+            << " (" << match.offset << ")\n";
+    }
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    try {
+        Options options;
+        try {
+            options = parse_options(argc, argv);
+        }
+        catch (const UsageError &error) {
+            std::cerr << "error: " << error.what() << '\n';
+            print_usage(std::cerr, argv[0]);
+            return 1;
+        }
+
+        if (options.help) {
+            print_usage(std::cout, argv[0]);
+            return 0;
+        }
+
+        if (options.group_filter.has_value()) {
+            const auto groups = known_groups();
+            if (std::find(groups.begin(), groups.end(), *options.group_filter) == groups.end()) {
+                std::cerr << "error: unknown group '" << *options.group_filter << "'\n";
+                print_usage(std::cerr, argv[0]);
+                return 1;
+            }
+        }
+
+        if (options.list_markers) {
+            list_markers(std::cout, options.group_filter);
+            if (!options.file_path.has_value()) {
+                return 0;
+            }
+            std::cout << '\n';
+        }
+
+        const std::filesystem::path input_path = *options.file_path;
+        const std::uint64_t file_size = std::filesystem::file_size(input_path);
+        const std::size_t thread_count = choose_thread_count(file_size, options.thread_count);
+
+        const int raw_fd = ::open(input_path.c_str(), O_RDONLY);
+        if (raw_fd < 0) {
+            throw std::runtime_error(format_errno("failed to open " + input_path.string()));
+        }
+        FileDescriptor fd(raw_fd);
+
+        std::vector<std::thread> threads;
+        std::vector<std::vector<Match>> thread_matches(thread_count);
+        std::exception_ptr worker_error;
+        std::mutex worker_error_mutex;
+
+        std::atomic<std::uint64_t> bytes_scanned{0};
+        std::atomic<bool> scan_done{false};
+
+        const std::uint64_t chunk_size = (file_size + thread_count - 1) / thread_count;
+
+        for (std::size_t i = 0; i < thread_count; ++i) {
+            const std::uint64_t start = chunk_size * i;
+            const std::uint64_t end = std::min<std::uint64_t>(file_size, start + chunk_size);
+
+            threads.emplace_back([&, i, start, end]() {
+                try {
+                    thread_matches[i] = scan_range(fd.get(), file_size, start, end,
+                                                   options.group_filter, bytes_scanned);
+                }
+                catch (...) {
+                    std::lock_guard<std::mutex> lock(worker_error_mutex);
+                    if (!worker_error) {
+                        worker_error = std::current_exception();
+                    }
+                }
+            });
+        }
+
+        // Show progress on stderr when scanning large files in a terminal.
+        std::thread progress_thread;
+        const bool show_progress = file_size > 0 && ::isatty(STDERR_FILENO);
+        if (show_progress) {
+            progress_thread = std::thread([&]() {
+                while (!scan_done.load(std::memory_order_relaxed)) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+                    if (scan_done.load(std::memory_order_relaxed)) {
+                        break;
+                    }
+                    const std::uint64_t scanned = bytes_scanned.load(std::memory_order_relaxed);
+                    const int pct = static_cast<int>(scanned * 100 / file_size);
+                    std::cerr << '\r' << scanned << " / " << file_size
+                              << " bytes (" << pct << "%)   " << std::flush;
+                }
+                // Clear the progress line.
+                std::cerr << '\r' << std::string(60, ' ') << '\r' << std::flush;
+            });
+        }
+
+        for (auto &thread : threads) {
+            thread.join();
+        }
+
+        scan_done.store(true, std::memory_order_relaxed);
+        if (progress_thread.joinable()) {
+            progress_thread.join();
+        }
+
+        if (worker_error) {
+            std::rethrow_exception(worker_error);
+        }
+
+        std::vector<Match> matches;
+        for (auto &partial : thread_matches) {
+            matches.insert(matches.end(), partial.begin(), partial.end());
+        }
+
+        std::sort(matches.begin(), matches.end(), [](const Match &left, const Match &right) {
+            if (left.offset != right.offset) {
+                return left.offset < right.offset;
+            }
+            return left.marker_name < right.marker_name;
+        });
+
+        print_matches(matches, std::cout);
+    }
+    catch (const std::exception &error) {
+        std::cerr << "error: " << error.what() << '\n';
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@ namespace {
 
 struct Marker {
     std::string name;
+    std::string description;
     std::string group;
     std::vector<std::uint8_t> bytes;
 };
@@ -96,32 +97,34 @@ class FileDescriptor {
 
 std::vector<Marker> build_markers() {
     return {
-        {"HDF5_SIGNATURE", "HDF5", {0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a}},
-        {"TREE", "HDF5", {'T', 'R', 'E', 'E'}},
-        {"BTHD", "HDF5", {'B', 'T', 'H', 'D'}},
-        {"BTIN", "HDF5", {'B', 'T', 'I', 'N'}},
-        {"BTLF", "HDF5", {'B', 'T', 'L', 'F'}},
-        {"SNOD", "HDF5", {'S', 'N', 'O', 'D'}},
-        {"HEAP", "HDF5", {'H', 'E', 'A', 'P'}},
-        {"GCOL", "HDF5", {'G', 'C', 'O', 'L'}},
-        {"FRHP", "HDF5", {'F', 'R', 'H', 'P'}},
-        {"FHDB", "HDF5", {'F', 'H', 'D', 'B'}},
-        {"FHIB", "HDF5", {'F', 'H', 'I', 'B'}},
-        {"FSHD", "HDF5", {'F', 'S', 'H', 'D'}},
-        {"FSSE", "HDF5", {'F', 'S', 'S', 'E'}},
-        {"SMTB", "HDF5", {'S', 'M', 'T', 'B'}},
-        {"SMLI", "HDF5", {'S', 'M', 'L', 'I'}},
-        {"OHDR", "HDF5", {'O', 'H', 'D', 'R'}},
-        {"OCHK", "HDF5", {'O', 'C', 'H', 'K'}},
-        {"FAHD", "HDF5", {'F', 'A', 'H', 'D'}},
-        {"FADB", "HDF5", {'F', 'A', 'D', 'B'}},
-        {"EAHD", "HDF5", {'E', 'A', 'H', 'D'}},
-        {"EAIB", "HDF5", {'E', 'A', 'I', 'B'}},
-        {"EASB", "HDF5", {'E', 'A', 'S', 'B'}},
-        {"EADB", "HDF5", {'E', 'A', 'D', 'B'}},
-        {"OHDH", "Onion", {'O', 'H', 'D', 'H'}},
-        {"OWHR", "Onion", {'O', 'W', 'H', 'R'}},
-        {"ORRS", "Onion", {'O', 'R', 'R', 'S'}},
+        {"HDF5_SIGNATURE", "HDF5 file signature", "HDF5",
+         {0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a}},
+        {"TREE", "Version 1 B-tree node", "HDF5", {'T', 'R', 'E', 'E'}},
+        {"BTHD", "Version 2 B-tree header", "HDF5", {'B', 'T', 'H', 'D'}},
+        {"BTIN", "Version 2 B-tree internal node", "HDF5", {'B', 'T', 'I', 'N'}},
+        {"BTLF", "Version 2 B-tree leaf node", "HDF5", {'B', 'T', 'L', 'F'}},
+        {"SNOD", "Symbol table node", "HDF5", {'S', 'N', 'O', 'D'}},
+        {"HEAP", "Local heap", "HDF5", {'H', 'E', 'A', 'P'}},
+        {"GCOL", "Global heap collection", "HDF5", {'G', 'C', 'O', 'L'}},
+        {"FRHP", "Fractal heap header", "HDF5", {'F', 'R', 'H', 'P'}},
+        {"FHDB", "Fractal heap direct block", "HDF5", {'F', 'H', 'D', 'B'}},
+        {"FHIB", "Fractal heap indirect block", "HDF5", {'F', 'H', 'I', 'B'}},
+        {"FSHD", "Free-space manager header", "HDF5", {'F', 'S', 'H', 'D'}},
+        {"FSSE", "Free-space section information", "HDF5", {'F', 'S', 'S', 'E'}},
+        {"SMTB", "Shared Object Header Message table", "HDF5", {'S', 'M', 'T', 'B'}},
+        {"SMLI", "Shared message record list", "HDF5", {'S', 'M', 'L', 'I'}},
+        {"OHDR", "Version 2 object header", "HDF5", {'O', 'H', 'D', 'R'}},
+        {"OCHK", "Version 2 object header continuation block", "HDF5",
+         {'O', 'C', 'H', 'K'}},
+        {"FAHD", "Fixed Array header", "HDF5", {'F', 'A', 'H', 'D'}},
+        {"FADB", "Fixed Array data block", "HDF5", {'F', 'A', 'D', 'B'}},
+        {"EAHD", "Extensible Array header", "HDF5", {'E', 'A', 'H', 'D'}},
+        {"EAIB", "Extensible Array index block", "HDF5", {'E', 'A', 'I', 'B'}},
+        {"EASB", "Extensible Array secondary block", "HDF5", {'E', 'A', 'S', 'B'}},
+        {"EADB", "Extensible Array data block", "HDF5", {'E', 'A', 'D', 'B'}},
+        {"OHDH", "Onion History Data Header", "Onion", {'O', 'H', 'D', 'H'}},
+        {"OWHR", "Onion Whole-History Record", "Onion", {'O', 'W', 'H', 'R'}},
+        {"ORRS", "Onion Revision Record Signature", "Onion", {'O', 'R', 'R', 'S'}},
     };
 }
 
@@ -180,7 +183,7 @@ std::vector<std::string> known_groups() {
 
 void print_usage(std::ostream &out, const char *argv0) {
     out << "Usage:\n"
-        << "  " << argv0 << " --list-markers [FILE]\n"
+        << "  " << argv0 << " [--list-markers/-l] [FILE]\n"
         << "  " << argv0 << " [--threads/-j N] [--group GROUP] FILE\n"
         << "  " << argv0 << " --help\n"
         << "\n"
@@ -212,7 +215,7 @@ Options parse_options(int argc, char **argv) {
             continue;
         }
 
-        if (arg == "--list-markers") {
+        if (arg == "--list-markers" || arg == "-l") {
             options.list_markers = true;
             continue;
         }
@@ -256,7 +259,7 @@ Options parse_options(int argc, char **argv) {
     }
 
     if (!options.help && !options.list_markers && !options.file_path.has_value()) {
-        throw UsageError("an input file is required unless --list-markers is used");
+        throw UsageError("an input file is required unless --list-markers/-l is used");
     }
 
     return options;
@@ -280,6 +283,7 @@ void list_markers(std::ostream &out, const std::optional<std::string> &group_fil
     out << "Markers defined in the HDF5 and Onion formats:\n\n";
 
     std::string current_group;
+    const std::size_t col_width = max_marker_name_width();
     for (const auto &marker : markers()) {
         if (group_filter.has_value() && marker.group != *group_filter) {
             continue;
@@ -290,7 +294,9 @@ void list_markers(std::ostream &out, const std::optional<std::string> &group_fil
             out << current_group << ":\n";
         }
 
-        out << "  " << marker.name;
+        out << "  " << std::left << std::setfill(' ')
+            << std::setw(static_cast<int>(col_width)) << marker.name
+            << "  " << marker.description;
 
         const bool has_non_ascii = std::any_of(marker.bytes.begin(), marker.bytes.end(),
             [](std::uint8_t b) { return b < 0x20 || b > 0x7e; });


### PR DESCRIPTION
This is a little tool to bootstrap a file analysis. It lists relevant sites ("magic markers") for the investigation to begin.

**WARNING:** The tool may list false positives.

For example, an occurrence of the byte sequence `OHDR` may be a coincidence, and not signal the beginning of an HDF5 file format object header.

Use with caution and common sense!