### PR TITLE
Pkdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+.claude
+.codex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,76 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 project(h5markers LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(h5markers
     src/h5markers.cpp
 )
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 target_compile_options(h5markers PRIVATE
-    -Wall
-    -Wextra
-    -Wpedantic
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra -Wpedantic>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4>
 )
 
 find_package(Threads REQUIRED)
 target_link_libraries(h5markers PRIVATE Threads::Threads)
+
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+set(PKDOC_SPECS
+    earray
+    farray
+    messages
+    ohdr
+    superblock
+    v1_btree
+    v2_btree
+)
+
+set(PKDOC_GENERATED_FILES)
+set(PKDOC_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/tools/pkdoc.py")
+set(PKDOC_CHECK_COMMANDS)
+
+foreach(PKDOC_SPEC IN LISTS PKDOC_SPECS)
+    set(PKDOC_SIDECAR "${CMAKE_CURRENT_SOURCE_DIR}/docs/spec/${PKDOC_SPEC}.yml")
+    set(PKDOC_PICKLE "${CMAKE_CURRENT_SOURCE_DIR}/pickles/${PKDOC_SPEC}.pk")
+    set(PKDOC_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/docs/generated/${PKDOC_SPEC}.md")
+
+    list(APPEND PKDOC_GENERATED_FILES "${PKDOC_OUTPUT}")
+    list(APPEND PKDOC_SOURCE_FILES "${PKDOC_SIDECAR}" "${PKDOC_PICKLE}")
+    list(APPEND PKDOC_CHECK_COMMANDS
+        COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/tools/pkdoc.py"
+                --doc "${PKDOC_SIDECAR}"
+                --check
+    )
+
+    add_custom_command(
+        OUTPUT "${PKDOC_OUTPUT}"
+        COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/tools/pkdoc.py"
+                --doc "${PKDOC_SIDECAR}"
+                --out "${PKDOC_OUTPUT}"
+        DEPENDS
+            "${CMAKE_CURRENT_SOURCE_DIR}/tools/pkdoc.py"
+            "${PKDOC_SIDECAR}"
+            "${PKDOC_PICKLE}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        COMMENT "Generating docs/generated/${PKDOC_SPEC}.md"
+        VERBATIM
+    )
+endforeach()
+
+add_custom_target(docs
+    DEPENDS ${PKDOC_GENERATED_FILES}
+)
+
+add_custom_target(docs-check
+    ${PKDOC_CHECK_COMMANDS}
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    COMMENT "Checking generated documentation sidecars"
+    VERBATIM
+    USES_TERMINAL
+)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The goal is to describe HDF5 on-disk structures as executable binary format defi
 
 This repository is a work in progress. The current pickles focus on core HDF5 metadata structures, including the superblock, B-trees, object headers, and related messages.
 
-## Repository Layout - Pickles
+## Repository Layout
+
+### Core Pickles
 
 - [`pickles/common.pk`](pickles/common.pk): shared helpers and common definitions
 - [`pickles/superblock.pk`](pickles/superblock.pk): HDF5 superblock definitions
@@ -18,6 +20,16 @@ This repository is a work in progress. The current pickles focus on core HDF5 me
 - [`pickles/farray.pk`](pickles/farray.pk): fixed array chunk index definitions
 - [`pickles/earray.pk`](pickles/earray.pk): extensible array chunk index definitions
 - [`pickles/lookup3.pk`](pickles/lookup3.pk): implementation of the lookup3 hash function used for checksums
+
+### Documentation
+
+- [`MARKERS.md`](MARKERS.md): list of known on-disk markers in HDF5 and Onion files
+- [`TOOLS.md`](TOOLS.md): documentation for tools included in this repository, including the marker scanner and interactive explorer
+- [`TUTORIAL.md`](TUTORIAL.md): step-by-step tutorial for using the pickles and tools in this repository
+
+### Examples
+
+- [`examples/`](examples/): example HDF5 files and GNU poke sessions demonstrating the use of the pickles and tools in this repository
 
 ## Acknowledgments
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,67 @@
+# Documentation workflow
+
+Specification Markdown is generated from two sources of truth:
+
+- **`pickles/*.pk`** — the executable format definitions (structure, types, constraints)
+- **`docs/spec/*.yml`** — prose sidecars (field descriptions, introductory text,
+  version notes, cross-references)
+
+The generator lives in `tools/pkdoc.py` and requires PyYAML (`pip install pyyaml`).
+
+## Generate
+
+Run from the repository root:
+
+```sh
+cmake -S . -B build
+cmake --build build --target docs
+```
+
+Output lands in `docs/generated/<name>.md`.
+
+## Check consistency
+
+The `--check` flag verifies that every type and field name in the sidecar
+actually appears in the corresponding pickle, catching stale documentation
+after a rename:
+
+```sh
+cmake --build build --target docs-check
+```
+
+Exit code 0 = clean; 1 = issues found.  Wire this into CI so drift is
+caught automatically when a pickle field is renamed.
+
+## Adding a new pickle
+
+1. Write `docs/spec/<pickle-stem>.yml` using the schema below.
+2. Add `<pickle-stem>` to `PKDOC_SPECS` in `CMakeLists.txt`.
+3. Run `cmake --build build --target docs-check` to confirm all names resolve.
+4. Run `cmake --build build --target docs` to generate the Markdown.
+5. Commit both the sidecar and the generated file together.
+
+## Sidecar schema
+
+```yaml
+pickle: foo.pk          # which pickle this documents (required)
+section: "V.B. Title"  # becomes the H1 heading
+intro: |               # introductory prose (plain Markdown)
+  …
+
+types:
+  TypeName:
+    desc: "One-sentence description of the type."
+    fields:             # top-level fields of the struct, in order
+      field_name:
+        desc: "What this field means."
+        note: "Optional italicised note (version caveat, units, etc.)."
+    variants:           # union arms (named after the arm identifier in the pickle)
+      arm_name:
+        desc: "When this arm is active and what it means."
+        fields:
+          field_name:
+            desc: "…"
+```
+
+Fields and variants may be nested to any depth by adding a `variants:` key
+inside a variant entry.

--- a/docs/generated/earray.md
+++ b/docs/generated/earray.md
@@ -1,0 +1,192 @@
+# C.IV. Extensible Array Chunk Index
+
+The Extensible Array (EA) is a chunk index used for datasets with
+exactly one unlimited dimension.  Unlike the Fixed Array it can grow
+in one direction without rebuilding the entire index.
+
+The structure is a four-level hierarchy:
+
+```
+Header (EAHD)
+  └─ Index Block (EAIB)
+       ├─ direct elements          (first idx_blk_elmts chunks)
+       ├─ direct data block addresses   (first iblk_nsblks secondary groups)
+       └─ secondary block addresses     (remaining secondary groups)
+            └─ Secondary Block (EASB)
+                 └─ Data Block addresses
+                      └─ Data Block (EADB)
+                           └─ [Data Block Pages]  (when paged)
+```
+
+Data blocks are organised into *secondary block groups* indexed by u = 0, 1, 2, …:
+
+| Group u | Data blocks in group | Elements per data block         |
+|---------|----------------------|---------------------------------|
+| u       | 2^(u/2)              | 2^((u+1)/2) × data_blk_min_elmts |
+
+The first `iblk_nsblks = 2 × log2(sup_blk_min_data_ptrs)` secondary
+block groups have their data block addresses stored directly in the
+index block.  The remaining groups are managed via separate Secondary
+Block structures.
+
+**Paging:** when a data block's element count exceeds
+`2^max_dblk_page_nelmts_bits`, elements are stored in separate data
+block pages appended immediately after the data block prefix in the
+file.  All pages within one data block hold the same number of elements.
+
+**Client IDs:**
+
+| ID | Name                   | Element layout                                         |
+|----|------------------------|--------------------------------------------------------|
+| 0  | H5EA_CLS_CHUNK_ID      | `sizeof_offsets`-byte chunk file address               |
+| 1  | H5EA_CLS_FILT_CHUNK_ID | chunk address + filtered size + 4-byte filter mask    |
+
+Use `print_ea(addr#B)` to map the header, print it and the index block,
+and recursively walk all reachable data blocks and secondary blocks.
+
+## `ea_chunk_elem`
+
+One element for a non-filtered chunk (client ID 0). Contains only the chunk's file address.
+
+| Field | Description |
+|-------|-------------|
+| `addr_raw` | File address of the chunk data (`sizeof_offsets` bytes). HADDR_UNDEF if the chunk has not been written. |
+
+
+## `ea_filt_chunk_elem`
+
+One element for a filtered chunk (client ID 1). Records the chunk address, its on-disk (post-filter) size, and the filter pipeline skip mask.
+
+| Field | Description |
+|-------|-------------|
+| `addr_raw` | File address of the filtered chunk data (`sizeof_offsets` bytes). |
+| `chunk_size_raw` | On-disk (filtered) size of the chunk in bytes (`global_ea_chunk_size_len` bytes = `raw_elmt_size − sizeof_offsets − 4`). |
+| `filter_mask` | Filter pipeline skip mask. Bit i set means filter i was not applied to this chunk. |
+
+
+## `ea_element`
+
+Dispatch union that resolves to the correct element layout based on `global_ea_client_id` at mapping time.
+
+### `non_filtered`
+
+Active when `global_ea_client_id == 0`. Wraps `ea_chunk_elem`.
+
+### `filtered`
+
+Active when `global_ea_client_id == 1`. Wraps `ea_filt_chunk_elem`.
+
+### `testing`
+
+Active when `global_ea_client_id == 2`. Wraps `ea_chunk_elem`. Added for compatibility with internal EA test files only; not part of the public format specification.
+
+
+## `ea_hdr`
+
+Extensible Array header (signature 'EAHD'). Stores the element type and all structural parameters of the array. Mapping this struct sets all `global_ea_*` parameters via constraint side-effects, including the derived counts `iblk_nsblks`, `ndblk_addrs`, `nsblk_addrs`, `arr_off_size`, and `dblk_page_nelmts`.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'E' 'A' 'H' 'D'. Must match exactly. |
+| `version` | Header format version. Must be 0. |
+| `client_id` | Element class: 0 = non-filtered chunk addresses, 1 = filtered chunk addresses. |
+| `raw_elmt_size` | On-disk size in bytes of each array element. |
+| `max_nelmts_bits` | Log₂ of the maximum number of elements the array can hold. Determines `arr_off_size = ⌈max_nelmts_bits / 8⌉`, the byte width used to encode array element offsets. |
+| `idx_blk_elmts` | Number of elements stored directly in the index block (the lowest-index chunks are stored here to avoid allocating data blocks for small datasets). |
+| `data_blk_min_elmts` | Minimum number of elements per data block (must be a power of two). Controls the element count per data block via `dblk_nelmts[u] = 2^((u+1)/2) × data_blk_min_elmts`. |
+| `sup_blk_min_data_ptrs` | Minimum number of data block pointers in a secondary block (must be a power of two). Controls the layout of the index block via `iblk_nsblks = 2 × log2(sup_blk_min_data_ptrs)`. |
+| `max_dblk_page_nelmts_bits` | Log₂ of the maximum number of elements per data block page. 0 means paging is disabled. |
+| `nsuper_blks_raw` | Total number of secondary blocks allocated (`sizeof_lengths` bytes). |
+| `super_blk_size_raw` | Total bytes consumed by all secondary blocks (`sizeof_lengths` bytes). |
+| `ndata_blks_raw` | Total number of data blocks allocated (`sizeof_lengths` bytes). |
+| `data_blk_size_raw` | Total bytes consumed by all data blocks (`sizeof_lengths` bytes). |
+| `max_idx_set_raw` | Highest element index that has been set (`sizeof_lengths` bytes). |
+| `nelmts_raw` | Total number of elements currently stored in the array (`sizeof_lengths` bytes). |
+| `idx_blk_addr_raw` | File address of the index block (`sizeof_offsets` bytes). |
+| `chksum` | Jenkins lookup3 checksum of all preceding header bytes. |
+
+
+## `ea_iblock`
+
+Extensible Array index block (signature 'EAIB'). Central dispatch structure. Holds the first `idx_blk_elmts` elements directly, then `ndblk_addrs` data block addresses for the first `iblk_nsblks` secondary block groups, then `nsblk_addrs` secondary block addresses for the remaining groups.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'E' 'A' 'I' 'B'. Must match exactly. |
+| `version` | Index block format version. Must be 0. |
+| `client_id` | Element class (mirrors `ea_hdr.client_id`). |
+| `hdr_addr_raw` | Back-pointer: file address of the Extensible Array header (`sizeof_offsets` bytes). |
+| `elements` | Array of `global_ea_idx_blk_elmts` elements stored inline (type `ea_element`). These are the lowest-index chunks and are accessed without following any data block pointer. |
+| `dblk_addrs` | `global_ea_ndblk_addrs × sizeof_offsets` byte array of data block file addresses. Entries are grouped by secondary block group u; within group u there are `2^(u/2)` addresses. HADDR_UNDEF entries indicate unallocated data blocks. |
+| `sblk_addrs` | `global_ea_nsblk_addrs × sizeof_offsets` byte array of secondary block file addresses for groups u = iblk_nsblks … nsblks−1. HADDR_UNDEF entries indicate unallocated secondary blocks. |
+| `chksum` | Jenkins lookup3 checksum of all preceding index block bytes. |
+
+
+## `ea_sblock`
+
+Extensible Array secondary block (signature 'EASB'). Manages the data blocks for one secondary block group u. Before mapping, call `set_ea_sblock_idx(u)` to configure `global_ea_sblk_ndblks`, `global_ea_sblk_dblk_nelmts`, `global_ea_sblk_dblk_npages`, and `global_ea_sblk_total_page_init_size`.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'E' 'A' 'S' 'B'. Must match exactly. |
+| `version` | Secondary block format version. Must be 0. |
+| `client_id` | Element class (mirrors `ea_hdr.client_id`). |
+| `hdr_addr_raw` | Back-pointer: file address of the Extensible Array header (`sizeof_offsets` bytes). |
+| `block_off_raw` | Array-element offset of the first element reachable via this secondary block (`global_ea_arr_off_size` bytes = ⌈max_nelmts_bits / 8⌉). |
+| `page_init_flags` | Page-initialisation bitmask for the data blocks managed by this secondary block (`global_ea_sblk_total_page_init_size` bytes = `ndblks × ⌈dblk_npages / 8⌉`). Zero-length when the data blocks in this group are not paged. |
+| `dblk_addrs` | `global_ea_sblk_ndblks × sizeof_offsets` byte array of data block file addresses for this secondary block group. HADDR_UNDEF entries indicate unallocated data blocks. |
+| `chksum` | Jenkins lookup3 checksum of all preceding secondary block bytes. |
+
+
+## `ea_dblock_nopaged`
+
+Extensible Array data block, non-paged layout (signature 'EADB'). Used when `global_ea_dblk_npages == 0`. All `global_ea_dblk_nelmts` elements are stored inline after the block header. Before mapping, call `set_ea_dblock(nelmts)` with the element count for this particular data block.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'E' 'A' 'D' 'B'. Must match exactly. |
+| `version` | Data block format version. Must be 0. |
+| `client_id` | Element class (mirrors `ea_hdr.client_id`). |
+| `hdr_addr_raw` | Back-pointer: file address of the Extensible Array header (`sizeof_offsets` bytes). |
+| `block_off_raw` | Array-element offset of the first element in this data block (`global_ea_arr_off_size` bytes). |
+| `elements` | Array of `global_ea_dblk_nelmts` inline elements (type `ea_element`). |
+| `chksum` | Jenkins lookup3 checksum of all preceding data block bytes. |
+
+
+## `ea_dblock_paged`
+
+Extensible Array data block, paged layout (signature 'EADB'). Used when `global_ea_dblk_npages > 0`. Captures only the block prefix; elements are in `ea_dblk_page` records that follow the prefix consecutively in the file. Before mapping, call `set_ea_dblock(nelmts)`.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'E' 'A' 'D' 'B'. Must match exactly. |
+| `version` | Data block format version. Must be 0. |
+| `client_id` | Element class (mirrors `ea_hdr.client_id`). |
+| `hdr_addr_raw` | Back-pointer: file address of the Extensible Array header (`sizeof_offsets` bytes). |
+| `block_off_raw` | Array-element offset of the first element in this data block (`global_ea_arr_off_size` bytes). |
+| `chksum` | Jenkins lookup3 checksum of all bytes from `signature` through `block_off_raw`. |
+
+
+## `ea_dblock`
+
+Top-level Extensible Array data block dispatch union (signature 'EADB'). Selects `ea_dblock_paged` when `global_ea_dblk_npages > 0`, otherwise `ea_dblock_nopaged`. Map with `set_ea_dblock(nelmts)` then `var db = ea_dblock @ addr#B`.
+
+### `paged`
+
+Paged prefix layout. Active when `global_ea_dblk_npages > 0`.
+
+### `nopaged`
+
+Inline element layout. Active when `global_ea_dblk_npages == 0`.
+
+
+## `ea_dblk_page`
+
+Extensible Array data block page. No on-disk signature; pages are appended consecutively to a paged data block prefix. Every page within one data block holds exactly `global_ea_dblk_page_nelmts` elements (data block sizes always divide evenly into pages). Map with `var pg = ea_dblk_page @ page_offset#B`.
+
+| Field | Description |
+|-------|-------------|
+| `elements` | Array of `global_ea_dblk_page_nelmts` elements (type `ea_element`). |
+| `chksum` | Jenkins lookup3 checksum of all preceding page bytes. |
+
+

--- a/docs/generated/farray.md
+++ b/docs/generated/farray.md
@@ -1,0 +1,132 @@
+# C.III. Fixed Array Chunk Index
+
+The Fixed Array (FA) is a chunk index used for datasets with a fixed
+number of chunks — i.e. datasets whose every dimension is either fixed
+in size or has at most one unlimited dimension that never grows beyond
+a single chunk in that dimension.  It provides O(1) access to any chunk
+by logical index.
+
+Two on-disk structures are defined:
+
+- **Header** (signature 'FAHD') — one per dataset; stores element
+  geometry and the address of the data block.
+- **Data Block** (signature 'FADB') — holds the actual chunk addresses
+  (and, for filtered datasets, per-chunk metadata).
+
+**Paging:** when the element count exceeds `2^max_dblk_page_nelmts_bits`
+the data block is split into fixed-size pages stored consecutively after
+the data block prefix in the file.  The prefix then records only the
+page-initialisation bitmask; elements live in `fa_dblk_page` records.
+When `max_dblk_page_nelmts_bits == 0` or the element count is small
+enough, all elements are stored directly in the data block (`fa_dblock_nopaged`).
+
+**Client IDs:**
+
+| ID | Name                  | Element layout                                          |
+|----|-----------------------|---------------------------------------------------------|
+| 0  | H5FA_CLS_CHUNK_ID     | `sizeof_offsets`-byte chunk file address                |
+| 1  | H5FA_CLS_FILT_CHUNK_ID| chunk address + filtered size + 4-byte filter mask     |
+
+Use `print_fa(addr#B)` to map the header, print it, and recursively
+print the data block and all pages.
+
+## `fa_chunk_elem`
+
+One element for a non-filtered chunk (client ID 0). Contains only the chunk's file address.
+
+| Field | Description |
+|-------|-------------|
+| `addr_raw` | File address of the chunk data (`sizeof_offsets` bytes). HADDR_UNDEF if the chunk has not been written. |
+
+
+## `fa_filt_chunk_elem`
+
+One element for a filtered chunk (client ID 1). Stores the chunk address, its on-disk (post-filter) size, and the filter pipeline skip mask.
+
+| Field | Description |
+|-------|-------------|
+| `addr_raw` | File address of the filtered chunk data (`sizeof_offsets` bytes). |
+| `chunk_size_raw` | On-disk (filtered) size of the chunk in bytes (`global_fa_chunk_size_len` bytes = `raw_elmt_size − sizeof_offsets − 4`). |
+| `filter_mask` | Filter pipeline skip mask. Bit i set means filter i was not applied to this chunk. |
+
+
+## `fa_element`
+
+Dispatch union that resolves to the correct element layout based on `global_fa_client_id` at mapping time. Both arms have the same on-disk footprint (`raw_elmt_size` bytes) for a given header.
+
+### `non_filtered`
+
+Active when `global_fa_client_id == 0`. Wraps `fa_chunk_elem`.
+
+### `filtered`
+
+Active when `global_fa_client_id == 1`. Wraps `fa_filt_chunk_elem`.
+
+
+## `fa_hdr`
+
+Fixed Array header (signature 'FAHD'). Describes the element type and geometry of the entire fixed array. Mapping this struct automatically sets all `global_fa_*` parameters via constraint side-effects so that the data block and pages can be mapped immediately afterwards.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'F' 'A' 'H' 'D'. Must match exactly. |
+| `version` | Header format version. Must be 0. |
+| `client_id` | Element class: 0 = non-filtered chunk addresses, 1 = filtered chunk addresses. |
+| `raw_elmt_size` | On-disk size in bytes of each array element. For client ID 0 this equals `sizeof_offsets`; for client ID 1 it equals `sizeof_offsets + chunk_size_len + 4`. |
+| `max_dblk_page_nelmts_bits` | Log₂ of the maximum number of elements per data block page. 0 means paging is disabled and all elements are stored inline in the data block. |
+| `nelmts_raw` | Total number of elements (chunks) indexed by this fixed array (`sizeof_lengths` bytes). |
+| `dblk_addr_raw` | File address of the associated data block (`sizeof_offsets` bytes). |
+| `chksum` | Jenkins lookup3 checksum of all preceding header bytes. |
+
+
+## `fa_dblk_page`
+
+Fixed Array data block page. Only present when paging is active (`global_fa_npages > 0`). Pages have no on-disk signature; they are stored consecutively immediately after the data block prefix. All full pages hold `global_fa_dblk_page_nelmts` elements; the final page may hold fewer (`global_fa_last_page_nelmts`). Override `global_fa_page_nelmts` with `set_fa_page_nelmts(n)` before mapping the last page, then restore it with `reset_fa_page_nelmts`.
+
+| Field | Description |
+|-------|-------------|
+| `elements` | Array of `global_fa_page_nelmts` elements (type `fa_element`). |
+| `chksum` | Jenkins lookup3 checksum of all preceding page bytes. |
+
+
+## `fa_dblock_nopaged`
+
+Fixed Array data block, non-paged layout (signature 'FADB'). Used when `global_fa_npages == 0`. All `global_fa_nelmts` elements are stored inline in the `elements` array.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'F' 'A' 'D' 'B'. Must match exactly. |
+| `version` | Data block format version. Must be 0. |
+| `client_id` | Element class (mirrors `fa_hdr.client_id`). |
+| `hdr_addr_raw` | Back-pointer: file address of the Fixed Array header (`sizeof_offsets` bytes). |
+| `elements` | Array of `global_fa_nelmts` inline elements (type `fa_element`). |
+| `chksum` | Jenkins lookup3 checksum of all preceding data block bytes. |
+
+
+## `fa_dblock_paged`
+
+Fixed Array data block, paged layout (signature 'FADB'). Used when `global_fa_npages > 0`. This struct captures only the prefix; the actual elements are stored in `fa_dblk_page` records that follow immediately in the file. The page-initialisation bitmask tracks which pages have been written.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'F' 'A' 'D' 'B'. Must match exactly. |
+| `version` | Data block format version. Must be 0. |
+| `client_id` | Element class (mirrors `fa_hdr.client_id`). |
+| `hdr_addr_raw` | Back-pointer: file address of the Fixed Array header (`sizeof_offsets` bytes). |
+| `page_init_flags` | Page-initialisation bitmask (`global_fa_dblk_page_init_size` bytes = ⌈npages / 8⌉). Bit i is set when page i has been written to disk. |
+| `chksum` | Jenkins lookup3 checksum of all bytes from `signature` through `page_init_flags`. |
+
+
+## `fa_dblock`
+
+Top-level Fixed Array data block dispatch union (signature 'FADB'). Selects `fa_dblock_paged` when `global_fa_npages > 0`, otherwise `fa_dblock_nopaged`. Map with `var db = fa_dblock @ bytes_to_off(hdr.dblk_addr_raw)`.
+
+### `paged`
+
+Paged prefix layout. Active when `global_fa_npages > 0`.
+
+### `nopaged`
+
+Inline element layout. Active when `global_fa_npages == 0`.
+
+

--- a/docs/generated/messages.md
+++ b/docs/generated/messages.md
@@ -1,0 +1,740 @@
+# IV.A.2. Disk Format: Level 1A – Object Header Messages
+
+Object header messages carry all the metadata associated with an HDF5
+object. Each message occupies one slot in an object header chunk and
+is preceded by a `msg_prefix` (defined in `ohdr.pk`). The message
+payload begins immediately after the prefix.
+
+Message type identifiers range from 0x0000 to 0x0018. The
+`message_factory` function dispatches a raw type ID and file offset to
+the appropriate typed struct. Unknown types are returned as raw byte
+arrays and are silently skipped.
+
+Several messages exist in an "old" and a "new" versioned form:
+`H5O_msg_old_fill` / `H5O_msg_fill` and `H5O_msg_old_mtime` /
+`H5O_msg_mtime`. Applications should write only the new form; the old
+form is retained for reading legacy files.
+
+All fields are stored in little-endian byte order.
+
+## `dtype_hdr`
+
+8-byte common header present at the start of every Datatype message and embedded recursively in compound, enumerated, variable-length, and array types. Encodes the datatype class, format version, and class-specific flags.
+
+| Field | Description |
+|-------|-------------|
+| `flags` | Packed 32-bit field. Bits 0–3: datatype class (0 = fixed-point, 1 = floating-point, 2 = time, 3 = string, 4 = bitfield, 5 = opaque, 6 = compound, 7 = reference, 8 = enumerated, 9 = variable-length, 10 = array). Bits 4–7: format version. Bits 8–23: class bit-fields whose meaning depends on the class. |
+| `elm_size` | Size in bytes of one element of this datatype. |
+
+
+## `compound_props1`
+
+Per-member descriptor for a version 1 compound datatype. Names are padded to 8-byte boundaries and a legacy array-dimension block is stored but is ignored by all current implementations.
+
+| Field | Description |
+|-------|-------------|
+| `memb_name` | NUL-terminated member name string. |
+| `pad` | Zero bytes padding `memb_name` to the next 8-byte boundary. |
+| `memb_off` | 4-byte byte offset of this member within one compound element. |
+| `ndim` | Legacy: number of dimensions in the member's array descriptor. Always 0 in files written by the current library. |
+| `res1` | Reserved. Must be zero (3 bytes). |
+| `perm` | Legacy: permutation index for each dimension (4 bytes; ignored). |
+| `res2` | Reserved. Must be zero (4 bytes). |
+| `dim_sizes` | Legacy: 4 × 4 array of dimension sizes. Only the first `ndim` entries are meaningful; the rest are zero. |
+| `memb_hdr` | 8-byte `dtype_hdr` describing this member's datatype. |
+| `memb_props` | Variable-length type-class properties for the member's datatype. |
+
+
+## `compound_props2`
+
+Per-member descriptor for a version 2 compound datatype. Removes the legacy dimension block present in version 1.
+
+| Field | Description |
+|-------|-------------|
+| `memb_name` | NUL-terminated member name, padded to 8-byte boundary. |
+| `pad` | Zero bytes padding `memb_name` to the next 8-byte boundary. |
+| `memb_off` | 4-byte byte offset of this member within one compound element. |
+| `memb_hdr` | 8-byte `dtype_hdr` describing this member's datatype. |
+| `memb_props` | Variable-length type-class properties for the member's datatype. |
+
+
+## `compound_props3`
+
+Per-member descriptor for a version 3 compound datatype. The member offset field is variable-width (1, 2, 4, or 8 bytes) determined by the total size of the compound element.
+
+| Field | Description |
+|-------|-------------|
+| `memb_name` | NUL-terminated member name (no padding). |
+| `memb_off` | Variable-width byte offset of this member. Width is 1 byte if `elm_size < 256`, 2 bytes if `< 65536`, 4 bytes if `< 4 GB`, otherwise 8 bytes. |
+| `memb_hdr` | 8-byte `dtype_hdr` describing this member's datatype. |
+| `memb_props` | Variable-length type-class properties for the member's datatype. |
+
+
+## `enum_props`
+
+Per-member name entry for version 1 and 2 enumerated datatypes. In version 3 the names are stored as plain NUL-terminated strings without padding.
+
+| Field | Description |
+|-------|-------------|
+| `name` | NUL-terminated enumeration member name. |
+| `pad` | Zero bytes padding the name to the next 8-byte boundary. |
+
+
+## `array_props2`
+
+Array datatype dimension descriptor for version 2. Includes a permutation index array that is always set to identity order `(0, 1, 2, …)` in files written by the current library.
+
+| Field | Description |
+|-------|-------------|
+| `ndims` | Number of array dimensions. |
+| `res` | Reserved. Must be zero (3 bytes). |
+| `dim_size` | Array of `ndims` uint32 dimension extents. |
+| `perm_size` | Array of `ndims` uint32 permutation indices (legacy; always identity). |
+
+
+## `array_props3`
+
+Array datatype dimension descriptor for version 3. The permutation array is removed.
+
+| Field | Description |
+|-------|-------------|
+| `ndims` | Number of array dimensions. |
+| `dim_size` | Array of `ndims` uint32 dimension extents. |
+
+
+## `filt_descr`
+
+Descriptor for one filter in the filter pipeline message. Version 1 appends a `padding` field when `cd_nelmts` is odd; version 2 omits the padding.
+
+| Field | Description |
+|-------|-------------|
+| `id` | Filter identification number. Values 1–255 are reserved for filters registered with The HDF Group; values 256–65535 are available for third-party filters. Well-known IDs: 1 = DEFLATE (zlib), 2 = SHUFFLE, 3 = FLETCHER32, 4 = SZIP, 5 = NBIT, 6 = SCALEOFFSET. |
+| `name_len` | Byte length of the optional `name` array including the NUL terminator. Zero when no name is stored. |
+| `flags` | Filter flags. Bit 0: filter is optional — if it cannot be applied the data is stored without filtering. |
+| `cd_nelmts` | Number of uint32 client-data values in `cd_data`. |
+| `name` | Optional NUL-terminated filter name. Present only when `name_len > 0`. _optional_ |
+| `cd_data` | Array of `cd_nelmts` uint32 parameters passed to the filter. |
+| `padding` | 4-byte alignment padding. Present in version 1 only, and only when `cd_nelmts` is odd. _version 1 only, when cd_nelmts is odd_ |
+
+
+## `H5O_msg_nil`
+
+Null message (type 0x0000). An empty, zero-length payload used to fill gaps left when a previous message was deleted or when an object header chunk is created with reserved space.
+
+
+## `H5O_msg_sdspace`
+
+Dataspace message (type 0x0001). Describes the shape and dimensionality of a dataset, including current dimension sizes and, optionally, maximum dimension sizes.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Valid values: 1 and 2. |
+
+### `v1`
+
+Version 1 dataspace. Uses a fixed 5-byte reserved block.
+
+| Field | Description |
+|-------|-------------|
+| `ndims` | Number of dimensions (0 = scalar). |
+| `flags` | Bit 0: maximum dimension sizes are present (`max` field follows). Bit 1: permutation indices are present (`perm` field follows; never written by the library). |
+| `res` | Reserved. Must be zero (5 bytes). |
+| `dim_size` | Array of `ndims` current dimension sizes, each `sizeof_lengths` bytes. |
+| `max` | Array of `ndims` maximum dimension sizes. `0xFFFF…FF` denotes unlimited. Present when `flags` bit 0 is set. _optional_ |
+| `perm` | Permutation indices. Present when `flags` bit 1 is set. _optional; never written by the library_ |
+
+### `v2`
+
+Version 2 dataspace. Replaces the reserved block with an explicit space-type byte.
+
+| Field | Description |
+|-------|-------------|
+| `ndims` | Number of dimensions. |
+| `flags` | Bit 0: maximum dimension sizes are present (`max` field follows). |
+| `space_type` | Dataspace class: 0 = H5S_SCALAR, 1 = H5S_SIMPLE, 2 = H5S_NULL. |
+| `dim_size` | Array of `ndims` current dimension sizes. |
+| `max` | Array of `ndims` maximum dimension sizes. Present when `flags` bit 0 is set. _optional_ |
+
+
+## `H5O_msg_linfo`
+
+Link info message (type 0x0002). Carries addresses of the fractal heap and B-trees used for dense link storage, and optionally the maximum creation order index assigned to a link in this group.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Must be 0. |
+| `flags` | Bit 0: creation order is tracked — `max_corder` is present. Bit 1: creation order is indexed — `corder_bt2_addr_raw` is present. |
+| `max_corder` | Maximum creation order value assigned to a link. Present when `flags` bit 0 is set. _optional_ |
+| `fheap_addr_raw` | File address of the fractal heap for dense link storage. HADDR_UNDEF when compact. |
+| `name_bt2_addr_raw` | File address of the v2 B-tree indexing link names. HADDR_UNDEF when compact. |
+| `corder_bt2_addr_raw` | File address of the v2 B-tree indexing link creation order. Present when `flags` bit 1 is set. _optional_ |
+
+
+## `H5O_msg_dtype`
+
+Datatype message (type 0x0003). Fully describes the type of a dataset's elements or an attribute's values. The datatype class is encoded in `hdr.flags` bits 0–3; the format version in bits 4–7. Compound, enumerated, variable-length, and array types embed one or more recursive `dtype_hdr` + properties blocks.
+
+| Field | Description |
+|-------|-------------|
+| `hdr` | Common 8-byte datatype header (`dtype_hdr`): class, version, class flags, element size. |
+
+### `fixed_point`
+
+Class 0. Unsigned or signed integer stored in a fixed number of bits.
+
+| Field | Description |
+|-------|-------------|
+| `bit_offset` | Bit offset of the first significant bit within the element. |
+| `bit_precision` | Number of significant bits. |
+
+### `floating_point`
+
+Class 1. IEEE or VAX floating-point number. The byte order, padding, normalization, and exponent bias are encoded in `hdr.flags` class bits.
+
+| Field | Description |
+|-------|-------------|
+| `bit_offset` | Bit offset of the first significant bit. |
+| `bit_precision` | Total number of bits in the floating-point value. |
+| `eloc` | Bit position of the least-significant exponent bit. |
+| `esize` | Number of bits in the exponent. |
+| `mloc` | Bit position of the least-significant mantissa bit. |
+| `msize` | Number of bits in the mantissa. |
+| `ebias` | Exponent bias value. |
+
+### `time`
+
+Class 2. Fixed-precision time value. Byte order is in `hdr.flags` class bits.
+
+| Field | Description |
+|-------|-------------|
+| `bit_precision` | Number of bits used to represent the time value. |
+
+### `text_string`
+
+Class 3. Fixed-length character string. Padding type (null- terminate, null-pad, or space-pad) and character set (ASCII or UTF-8) are encoded entirely in `hdr.flags` class bits; there are no additional property bytes on disk.
+
+### `bitfield`
+
+Class 4. Sequence of bits within a larger byte array. Layout mirrors fixed-point.
+
+| Field | Description |
+|-------|-------------|
+| `bit_offset` | Bit offset of the first significant bit. |
+| `bit_precision` | Number of significant bits. |
+
+### `opaque`
+
+Class 5. Uninterpreted raw bytes. The tag length is encoded in `hdr.flags` class bits (bits 8–15).
+
+| Field | Description |
+|-------|-------------|
+| `tag` | ASCII tag string describing the opaque data. |
+| `pad` | Zero bytes padding `tag` to the next 8-byte boundary. |
+
+### `compound`
+
+Class 6. Heterogeneous record type. The number of members is encoded in `hdr.flags` class bits (bits 8–23). Member layout differs between format versions 1, 2, and 3.
+
+| Field | Description |
+|-------|-------------|
+| `membs` | Union holding the version-appropriate array of member descriptors. |
+
+#### `v1`
+
+Version 1 members: array of `compound_props1`, one entry per member.
+
+#### `v2`
+
+Version 2 members: array of `compound_props2`, one entry per member.
+
+#### `v3`
+
+Version 3 members: array of `compound_props3`, one entry per member.
+
+### `reference`
+
+Class 7. Reference to another HDF5 object or region. The reference type and, for version 4+, the encoded version are in `hdr.flags` class bits. No additional property bytes.
+
+### `enumeration`
+
+Class 8. Mapping of integer values to symbolic names. The number of members is in `hdr.flags` class bits (bits 8–23). Embeds a recursive base-type descriptor followed by member names and values.
+
+| Field | Description |
+|-------|-------------|
+| `base_hdr` | 8-byte `dtype_hdr` of the underlying integer base type. |
+| `base_props` | Type-class properties for the base type. |
+| `memb_names` | Union holding member name strings, version-dependent. |
+| `memb_values` | Packed array of `num_members × base_hdr.elm_size` bytes, one value per member. |
+
+#### `v1_2`
+
+Member names for versions 1 and 2: array of `enum_props`, each NUL-terminated and padded to 8 bytes.
+
+#### `v3`
+
+Member names for version 3: array of plain NUL-terminated strings.
+
+### `variable_length`
+
+Class 9. Variable-length sequence or string. The VL type (sequence vs. string) is in `hdr.flags` class bits. Embeds a recursive base-type descriptor.
+
+| Field | Description |
+|-------|-------------|
+| `base_hdr` | 8-byte `dtype_hdr` of the base element type. |
+| `base_props` | Type-class properties for the base type. |
+
+### `array`
+
+Class 10. Fixed-size multidimensional array of a base type. Dimension information differs between versions 2 and 3.
+
+| Field | Description |
+|-------|-------------|
+| `arr` | Union holding the version-appropriate dimension descriptor. |
+| `base_hdr` | 8-byte `dtype_hdr` of the array element type. |
+| `base_props` | Type-class properties for the element type. |
+
+#### `v2`
+
+Version 2 array dimensions: `array_props2` (with permutation array).
+
+#### `v3`
+
+Version 3 array dimensions: `array_props3` (without permutation array).
+
+
+## `H5O_msg_old_fill`
+
+Fill value message, old form (type 0x0004). Stores a single raw fill value without versioning or allocation-time metadata. Present only in legacy files; new files use `H5O_msg_fill`.
+
+| Field | Description |
+|-------|-------------|
+| `fill_size` | Size in bytes of the fill value. Zero means no fill value is defined. |
+| `fill_value` | Raw fill value bytes. Present only when `fill_size > 0`. _optional_ |
+
+
+## `H5O_msg_fill`
+
+Fill value message, new form (type 0x0005). Extends the old form with explicit allocation- and fill-time controls and a defined/ undefined flag.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Valid values: 1, 2, 3. |
+
+### `v1_v2`
+
+Versions 1 and 2: explicit allocation-time, fill-time, and defined flag.
+
+| Field | Description |
+|-------|-------------|
+| `alloc_time` | When storage space is allocated: 0 = early (on creation), 1 = late (on first write), 2 = incremental. |
+| `fill_time` | When fill values are written: 0 = on allocation, 1 = never, 2 = if user-defined fill value is set. |
+| `fill_defined` | Non-zero if a user-defined fill value is stored. |
+| `fill_size` | Byte size of the fill value. Present only when `fill_defined > 0`. _optional_ |
+| `fill_value` | Raw fill value bytes. Present when `fill_defined > 0` and `fill_size > 0`. _optional_ |
+
+### `v3`
+
+Version 3: allocation-time and fill-time are packed into a single flags byte; the fill-defined bit eliminates the separate `fill_defined` field.
+
+| Field | Description |
+|-------|-------------|
+| `flags` | Bits 0–1: allocation time (same values as v1/v2 `alloc_time`). Bits 2–3: fill time (same values as v1/v2 `fill_time`). Bit 5: fill value is defined (replaces the separate `fill_defined` field). |
+| `fill_size` | Byte size of the fill value. Present when `flags` bit 5 is set. _optional_ |
+| `fill_value` | Raw fill value bytes. Present when `flags` bit 5 is set and `fill_size > 0`. _optional_ |
+
+
+## `H5O_msg_link`
+
+Link message (type 0x0006). Describes one link within a group. The link type (hard, soft, external, or user-defined) is encoded in the `flags` field.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Must be 1. |
+| `flags` | Bits 0–1: byte width of the `lnk_len` field (00 = 1 byte, 01 = 2 bytes, 10 = 4 bytes, 11 = 8 bytes). Bit 2: creation order is stored (`corder` field present). Bit 3: link type is explicitly stored (`lnk_type` field present). Bit 4: character set is stored (`cset` field present). |
+| `lnk_type` | Link type byte. 0 = hard link, 1 = soft link, 64 = external link, 255 = user-defined link. Present only when `flags` bit 3 is set (otherwise the type is hard, i.e. 0). _optional_ |
+| `corder` | Link creation order value. Present only when `flags` bit 2 is set. _optional_ |
+| `cset` | Character set of the link name: 0 = ASCII, 1 = UTF-8. Present when `flags` bit 4 is set. _optional_ |
+| `lnk_len` | Byte length of the link name array `lnk_name`. Width determined by `flags` bits 0–1. |
+| `lnk_name` | Link name character array (not NUL-terminated). |
+| `ohdr_addr_raw` | Target object header address. Present only for hard links (`lnk_type == 0`). _hard links only_ |
+| `soft_len` | Byte length of the soft-link target string. Present only for soft links. _soft links only_ |
+| `soft_name` | Soft-link target path (not NUL-terminated). Present when `soft_len > 0`. _soft links only_ |
+| `ud_len` | Byte length of the user-defined link data. Present for external and user-defined links. _external/user-defined links only_ |
+| `ud_data` | User-defined link data. For external links this is a NUL-terminated file path followed by a NUL-terminated object path. Present when `ud_len > 0`. _external/user-defined links only_ |
+
+
+## `H5O_msg_layout`
+
+Data layout message (type 0x0008). Specifies how a dataset's raw data are stored on disk: compact (inside the object header), contiguous, chunked, or virtual. Four format versions are defined; versions 1 and 2 share the same struct.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Valid values: 1, 2, 3, 4. |
+
+### `v1_v2`
+
+Layout for versions 1 and 2. The layout class is a separate field from the dimensionality.
+
+| Field | Description |
+|-------|-------------|
+| `ndims` | Number of dimensions plus one (the extra entry holds the element size). |
+| `layout_class` | Storage class: 0 = compact, 1 = contiguous, 2 = chunked. |
+| `res` | Reserved. Must be zero (5 bytes). |
+
+#### `contig`
+
+Contiguous layout properties (layout_class == 1).
+
+| Field | Description |
+|-------|-------------|
+| `data_addr_raw` | File address of the contiguous data block. |
+| `dim_size` | Array of `ndims` uint32 dimension sizes. |
+
+#### `chunked`
+
+Chunked layout properties (layout_class == 2).
+
+| Field | Description |
+|-------|-------------|
+| `idx_addr_raw` | File address of the v1 B-tree chunk index. |
+| `dim_size` | Array of `ndims` uint32 dimension sizes (last entry = element size). |
+
+#### `compact`
+
+Compact layout properties (layout_class == 0).
+
+| Field | Description |
+|-------|-------------|
+| `dim_size` | Array of `ndims` uint32 dimension sizes. |
+| `size` | Number of bytes of raw data stored inline. |
+| `compact_data` | Inline raw data bytes. Present only when `size > 0`. _optional_ |
+
+### `v3`
+
+Layout version 3. Layout class moves to the front; dimensionality is per-class.
+
+| Field | Description |
+|-------|-------------|
+| `layout_class` | Storage class: 0 = compact, 1 = contiguous, 2 = chunked. |
+
+#### `compact`
+
+Compact storage (layout_class == 0).
+
+| Field | Description |
+|-------|-------------|
+| `size` | Number of bytes of raw data stored inline. |
+| `raw_data` | Inline raw data bytes. Present only when `size > 0`. _optional_ |
+
+#### `contig`
+
+Contiguous storage (layout_class == 1).
+
+| Field | Description |
+|-------|-------------|
+| `data_addr_raw` | File address of the contiguous data block. |
+| `data_size_raw` | Size in bytes of the contiguous data block. |
+
+#### `chunked`
+
+Chunked storage (layout_class == 2).
+
+| Field | Description |
+|-------|-------------|
+| `ndims` | Number of chunk dimensions. |
+| `idx_addr_raw` | File address of the v1 B-tree chunk index. |
+| `dim_size` | Array of `ndims` uint32 chunk dimension sizes. |
+
+### `v4`
+
+Layout version 4. Chunked storage gains an explicit index type field with per-type parameters; virtual storage is added.
+
+| Field | Description |
+|-------|-------------|
+| `layout_class` | Storage class: 0 = compact, 1 = contiguous, 2 = chunked, 3 = virtual. |
+
+#### `compact`
+
+Compact storage (layout_class == 0).
+
+| Field | Description |
+|-------|-------------|
+| `size` | Number of bytes of raw data stored inline. |
+| `raw_data` | Inline raw data bytes. Present only when `size > 0`. _optional_ |
+
+#### `contig`
+
+Contiguous storage (layout_class == 1).
+
+| Field | Description |
+|-------|-------------|
+| `data_addr_raw` | File address of the contiguous data block. |
+| `data_size_raw` | Size in bytes of the contiguous data block. |
+
+#### `chunked`
+
+Chunked storage (layout_class == 2).
+
+| Field | Description |
+|-------|-------------|
+| `flags` | Bit 0: chunk dimension sizes use a filter. Bit 1: a single-chunk index with filters is used (filter metadata present in the index parameters). |
+| `ndims` | Number of chunk dimensions. |
+| `enc_bytes_per_dim` | Number of bytes used to encode each entry of `dim_size`. |
+| `dim_size` | Array of `ndims` chunk dimension sizes, each `enc_bytes_per_dim` bytes. |
+| `idx_type` | Chunk index type: 1 = single-chunk, 2 = implicit (compact/contiguous), 3 = fixed array, 4 = extensible array, 5 = version 2 B-tree. |
+| `idx_addr_raw` | File address of the chunk index data structure. |
+
+##### `single`
+
+Single-chunk index parameters (idx_type == 1).
+
+| Field | Description |
+|-------|-------------|
+| `filter_chunk_size` | Filtered chunk size in bytes (`sizeof_lengths` bytes). Present only when `flags` bit 1 is set. _optional_ |
+| `filter_mask` | Filter pipeline skip mask for the single chunk. Present only when `flags` bit 1 is set. _optional_ |
+
+##### `implicit`
+
+Implicit index (idx_type == 2). No additional parameters stored.
+
+##### `farray`
+
+Fixed Array index parameters (idx_type == 3).
+
+| Field | Description |
+|-------|-------------|
+| `max_dblk_page_nelmts_bits` | Log2 of the maximum number of elements in a data block page. |
+
+##### `earray`
+
+Extensible Array index parameters (idx_type == 4).
+
+| Field | Description |
+|-------|-------------|
+| `max_nelmts_bits` | Log2 of the maximum number of elements in the array. |
+| `idx_blk_elmts` | Number of elements to store in the index block. |
+| `sup_blk_min_data_ptrs` | Minimum number of data block pointers in a super block. |
+| `data_blk_min_elmts` | Minimum number of elements per data block. |
+| `max_dblk_page_nelmts_bits` | Log2 of the maximum number of elements in a data block page. _1 byte in the pickle; the spec specifies 2 bytes_ |
+
+##### `bt2`
+
+Version 2 B-tree index parameters (idx_type == 5).
+
+| Field | Description |
+|-------|-------------|
+| `node_size` | Size of each B-tree node in bytes. |
+| `split_percent` | Node occupancy (%) above which the node is split. |
+| `merge_percent` | Node occupancy (%) below which two nodes are merged. |
+
+#### `virtual`
+
+Virtual storage (layout_class == 3).
+
+| Field | Description |
+|-------|-------------|
+| `gheap_addr_raw` | File address of the global heap collection holding the VDS mapping. |
+| `idx` | Index of the VDS entry within the global heap collection. |
+
+
+## `H5O_msg_ginfo`
+
+Group info message (type 0x000a). Stores optional parameters controlling when a group switches between compact and dense link storage, and estimated size hints for newly created groups.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Must be 0. |
+| `flags` | Bit 0: compact/dense phase-change thresholds are stored (`max_compact` and `min_dense` present). Bit 1: group size estimates are stored (`est_num_entries` and `est_name_len` present). |
+| `max_compact` | Maximum number of links in compact form before conversion to indexed. Present when `flags` bit 0 is set. _optional_ |
+| `min_dense` | Minimum number of links in indexed form before conversion to compact. Present when `flags` bit 0 is set. _optional_ |
+| `est_num_entries` | Estimated number of entries in new groups. Present when `flags` bit 1 is set. _optional_ |
+| `est_name_len` | Estimated average length of link names. Present when `flags` bit 1 is set. _optional_ |
+
+
+## `H5O_msg_pline`
+
+Filter pipeline message (type 0x000b). Lists the filters that are applied to a dataset's raw data in order. Versions 1 and 2 differ only in the filter descriptor layout.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Valid values: 1, 2. |
+| `nfilters` | Number of filter descriptors in the pipeline (0–32). |
+
+### `v1`
+
+Version 1 pipeline. The filter list is preceded by a 6-byte reserved block.
+
+| Field | Description |
+|-------|-------------|
+| `res` | Reserved. Must be zero (6 bytes). |
+| `filt_list` | Array of `nfilters` version 1 `filt_descr` entries. |
+
+### `v2`
+
+Version 2 pipeline. The reserved block is removed; the filter list begins immediately.
+
+| Field | Description |
+|-------|-------------|
+| `filt_list` | Array of `nfilters` version 2 `filt_descr` entries. |
+
+
+## `H5O_msg_attr`
+
+Attribute message (type 0x000c). Stores an attribute inline in the object header. Each attribute consists of a name, a datatype, a dataspace, and a data payload; versions 1 and 3 align the name, datatype, and dataspace to 8 bytes, while version 2 does not.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Valid values: 1, 2, 3. |
+| `flags` | Reserved in version 1 (must be zero). In versions 2 and 3: bit 0 = datatype is shared, bit 1 = dataspace is shared. |
+| `name_size` | Byte length of the `name` field (including NUL terminator in v1). |
+| `dtype_size` | Byte length of the `dtype` field. |
+| `dspace_size` | Byte length of the `dspace` field. |
+| `cset` | Character set of the attribute name: 0 = ASCII, 1 = UTF-8. Version 3 only. _version 3 only_ |
+| `name` | Attribute name bytes. In version 1 the length is rounded up to an 8-byte boundary; in versions 2 and 3 it is stored exactly. |
+| `dtype` | Raw datatype message bytes (parsed as `H5O_msg_dtype`). |
+| `dspace` | Raw dataspace message bytes (parsed as `H5O_msg_sdspace`). |
+| `data` | Raw attribute data bytes (size = `dtype.elm_size × product(dim_sizes)`). |
+
+
+## `H5O_msg_name`
+
+Object comment message (type 0x000d). Stores a short human-readable comment string for the object. There is no version or length field; the string is NUL-terminated and the message payload size determines its extent.
+
+| Field | Description |
+|-------|-------------|
+| `name` | NUL-terminated comment string. |
+
+
+## `H5O_msg_old_mtime`
+
+Modification time message, old form (type 0x000e). Stores an object modification time as broken-out calendar fields rather than a UNIX timestamp. Present only in legacy files; new files use `H5O_msg_mtime`.
+
+| Field | Description |
+|-------|-------------|
+| `year` | Calendar year as a signed 32-bit integer. |
+| `month` | Month of the year (1–12). |
+| `mday` | Day of the month (1–31). |
+| `hour` | Hour of the day (0–23). |
+| `minute` | Minute of the hour (0–59). |
+| `second` | Second of the minute (0–60, allowing for a leap second). |
+| `res` | Reserved. Must be zero (2 bytes). |
+
+
+## `H5O_msg_shmesg_table`
+
+Shared object header message table message (type 0x000f). Points to the file-level shared message (SOHM) master table and records the number of indexes it contains.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Must be 0. |
+| `addr_raw` | File address of the shared object header message master table. |
+| `nindexes` | Number of shared message indexes in the master table. |
+
+
+## `H5O_msg_cont`
+
+Object header continuation message (type 0x0010). Points to an additional object header chunk on disk, allowing an object header to span multiple non-contiguous blocks.
+
+| Field | Description |
+|-------|-------------|
+| `addr_raw` | File address of the continuation block. |
+| `size_raw` | Byte size of the continuation block. |
+
+
+## `H5O_msg_stab`
+
+Symbol table message (type 0x0011). Present on groups encoded with the version 1 (legacy) symbol table structure. Points to the group's v1 B-tree and local heap.
+
+| Field | Description |
+|-------|-------------|
+| `btree_addr_raw` | File address of the root node of the version 1 group B-tree. |
+| `heap_addr_raw` | File address of the local heap containing link name strings. |
+
+
+## `H5O_msg_mtime`
+
+Modification time message, new form (type 0x0012). Stores the object modification time as a UNIX timestamp.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Must be 1. |
+| `res` | Reserved. Must be zero (3 bytes). |
+| `seconds` | UNIX timestamp (seconds since 1970-01-01 00:00:00 UTC) of the last metadata modification. |
+
+
+## `H5O_msg_btreek`
+
+Version 1 B-tree K values message (type 0x0013). Overrides the file-global B-tree K values from the superblock for this particular object. Stored in the superblock extension object header.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Must be 0. |
+| `btree_k_chunk` | Internal node K value for the indexed (chunked) storage v1 B-tree. |
+| `btree_k_snode` | Internal node K value for the group (symbol table) v1 B-tree. |
+| `sym_leaf_k` | Leaf node K value for the group (symbol table) v1 B-tree. |
+
+
+## `H5O_msg_drvinfo`
+
+Driver information message (type 0x0014). Stores a driver-specific opaque information block identified by an 8-byte ASCII name. Written only by drivers that need to persist private metadata (e.g. multi or family virtual file drivers).
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Must be 0. |
+| `name` | 8-byte ASCII driver name (not NUL-terminated). Identifies the driver and the format of `info_buf`. |
+| `info_len` | Byte size of `info_buf`. |
+| `info_buf` | Driver-specific information bytes of length `info_len`. |
+
+
+## `H5O_msg_ainfo`
+
+Attribute info message (type 0x0015). Stores addresses of the fractal heap and B-trees used for dense attribute storage, mirrors `H5O_msg_linfo` but for attributes rather than links.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Must be 0. |
+| `flags` | Bit 0: creation order is tracked — `max_crt_idx` is present. Bit 1: creation order is indexed — `corder_bt2_addr_raw` is present. |
+| `max_crt_idx` | Maximum creation order value assigned to an attribute. Present when `flags` bit 0 is set. _optional_ |
+| `fheap_addr_raw` | File address of the fractal heap for dense attribute storage. HADDR_UNDEF when compact. |
+| `name_bt2_addr_raw` | File address of the v2 B-tree indexing attribute names. |
+| `corder_bt2_addr_raw` | File address of the v2 B-tree indexing attribute creation order. Present when `flags` bit 1 is set. _optional_ |
+
+
+## `H5O_msg_refcount`
+
+Object reference count message (type 0x0016). Stores the count of hard links pointing to the object when that count exceeds what fits in the version 1 object header's 32-bit field.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Must be 0. |
+| `ref_cnt` | Current hard-link reference count. |
+
+
+## `H5O_msg_fsinfo`
+
+File space info message (type 0x0017). Describes the file space management strategy and stores addresses of the free-space managers for small and large allocations. Stored in the superblock extension.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Values 0 and 1 use identical layouts. |
+| `strategy` | File space management strategy: 1 = FSM_AGGR (free-space manager with aggregation), 2 = PAGE (paged allocation), 3 = AGGR (aggregation only), 4 = NONE (no tracking). |
+| `persist` | Non-zero if the free-space manager state is persisted across file opens. |
+| `threshold` | Minimum free-space section size (`sizeof_lengths` bytes) that is tracked. |
+| `page_size` | File space page size (`sizeof_lengths` bytes). _field position differs from the specification_ |
+| `pgend_meta_thres` | Threshold for storing small metadata at the end of a page. |
+| `eoa` | Stored end-of-address value (`sizeof_offsets` bytes). |
+| `small_fs_addr` | Array of 6 file addresses (`sizeof_offsets` bytes each) for the small-allocation free-space managers, one per allocation type. |
+| `large_fs_addr` | Array of 6 file addresses for the large-allocation free-space managers, one per allocation type. |
+
+
+## `H5O_msg_mdci`
+
+Metadata cache image message (type 0x0018). Points to a serialized snapshot of the metadata cache written at file close to accelerate the next file open. Not described in the public format specification.
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version. Must be 0. |
+| `image_addr_raw` | File address of the serialized metadata cache image block. |
+| `image_size` | Byte size of the metadata cache image block (`sizeof_lengths` bytes). |
+
+

--- a/docs/generated/ohdr.md
+++ b/docs/generated/ohdr.md
@@ -1,0 +1,106 @@
+# IV.A.2. Disk Format: Level 1A – Object Headers
+
+Object headers store all metadata associated with an HDF5 data object
+(a group or a dataset). Every object header is composed of a prefix
+followed by a sequence of variable-length messages; the messages
+describe the object's dataspace, datatype, storage layout, attributes,
+and other properties.
+
+Two object header versions are defined. Version 1 is the original
+format. Version 2 is more compact: it narrows several fields, makes
+timestamps and attribute phase-change thresholds optional, and adds a
+checksum over the entire header.
+
+An object header may span more than one contiguous block on disk.
+Additional blocks are called continuation chunks and are referenced by
+Object Header Continuation messages (type 0x0010) within the preceding
+chunk. Each version 2 continuation chunk is delimited by the 4-byte
+signature 'O' 'C' 'H' 'K' and ends with a 4-byte checksum.
+
+All object header fields are stored in little-endian byte order.
+
+## `Timestamps`
+
+Four UNIX timestamps optionally embedded in a version 2 object header. Present when bit 5 of the object header `flags` field is set. Each value is a 32-bit unsigned seconds count relative to the UNIX epoch (1970-01-01 00:00:00 UTC).
+
+| Field | Description |
+|-------|-------------|
+| `access` | Time of the last read access to the object. |
+| `modification` | Time of the last write to the object's raw data. |
+| `change` | Time of the last change to the object's metadata. |
+| `birth` | Time at which the object was created. |
+
+
+## `AttrPhase`
+
+Attribute storage phase-change thresholds optionally embedded in a version 2 object header. Present when bit 4 of `flags` is set. These thresholds control when the HDF5 library switches between compact attribute storage (inside the object header) and indexed attribute storage (in a fractal heap and B-tree).
+
+| Field | Description |
+|-------|-------------|
+| `max_compact` | Maximum number of attributes stored in compact form before the library converts to indexed storage. Once the count exceeds this value the library migrates to a fractal heap and B-tree. |
+| `min_dense` | Minimum number of attributes that must remain in indexed storage before the library converts back to compact form. Must be less than or equal to `max_compact`. |
+
+
+## `msg_prefix`
+
+Fixed-size header that precedes every message payload in an object header chunk. The layout differs between version 1 and version 2 headers; the active arm is selected by the global version state set when the enclosing `ohdr` is mapped.
+
+### `v1_msg_prefix`
+
+Version 1 message prefix (5 bytes of declared fields; the `Get_messages` logic accounts for 3 additional reserved bytes beyond this struct, giving an effective prefix size of 8 bytes).
+
+| Field | Description |
+|-------|-------------|
+| `msg_type` | 16-bit message type identifier. Values 0x0000–0x001F are defined by the HDF5 specification; all others are reserved. |
+| `msg_size` | Size of the message payload in bytes, not including this prefix or the 3 reserved bytes that follow it. |
+| `msg_flags` | Bit flags applying to this message. Bit 0: message data is constant after object creation and may be cached or shared. Bit 1: message is shared (payload is a Shared Message record rather than the message data itself). Bit 2: this message must not be shared. Bit 3: the HDF5 library may skip this message on open if it does not understand it. Bit 4: this message was marked as shareable but has not yet been moved to the shared message table. Bit 5: the object header was created before version 1.6 and this message was not originally encoded as a shared message. |
+
+### `v2_msg_prefix`
+
+Version 2 message prefix (4 bytes without creation-order tracking, 6 bytes with it). The type field narrows from 16 to 8 bits compared with the version 1 prefix.
+
+| Field | Description |
+|-------|-------------|
+| `msg_type` | 8-bit message type identifier. |
+| `msg_size` | Size of the message payload in bytes, not including this prefix. |
+| `msg_flags` | Bit flags (same bit definitions as in `v1_msg_prefix`). |
+| `crt_order` | Creation order index of this message within the object header. Present only when bit 2 of the enclosing object header's `flags` field is set. _optional_ |
+
+
+## `ohdr`
+
+An HDF5 object header in either version 1 or version 2 format. The first four bytes are mapped twice: once as `sig_peek` (pinned at offset 0 without consuming bytes) to select the correct union arm, and again as part of the chosen version struct.
+
+| Field | Description |
+|-------|-------------|
+| `sig_peek` | Four bytes read at file offset 0 of the header without advancing the read position. If equal to the signature 'O' 'H' 'D' 'R' the version 2 arm is selected; otherwise the version 1 arm is selected. |
+
+### `v2`
+
+Version 2 object header layout (identified by the 4-byte signature 'O' 'H' 'D' 'R'). More compact than version 1; adds a checksum and optional timestamps.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'O' 'H' 'D' 'R'. Must match the constant V2_SIG. |
+| `version` | Object header version number. Must be 2. |
+| `flags` | Bit flags controlling optional fields and the encoding of `chunk0_size`. Bits 0–1: byte width of `chunk0_size`: 00 = 1 byte, 01 = 2 bytes, 10 = 4 bytes, 11 = 8 bytes. Bit 2: creation-order tracking is active — message prefixes include the optional `crt_order` field. Bit 3: a creation-order index (B-tree) is maintained for the attributes of this object. Bit 4: the `attr_phase` field is present. Bit 5: the `timestamps` field is present. |
+| `timestamps` | Optional creation and access timestamps (type `Timestamps`). Present when `flags` bit 5 is set. _optional_ |
+| `attr_phase` | Optional attribute phase-change thresholds (type `AttrPhase`). Present when `flags` bit 4 is set. _optional_ |
+| `chunk0_size` | Size in bytes of the message data in the first object header chunk. Encoded as 1, 2, 4, or 8 bytes according to `flags` bits 0–1. The message data immediately follows this field and is not itself part of the on-disk `ohdr` struct; it is accessed via the internal `_msg_chunk` wrapper. |
+| `gap` | Zero or more padding bytes between the last message and the checksum in the first chunk. Present only when the messages do not fill the chunk exactly (i.e. when `chunk0_size` is not divisible by the message prefix size). _optional_ |
+| `chksum` | 4-byte Jenkins lookup3 checksum computed over all bytes of the object header from `signature` through the last byte of `gap` (or of the final message if there is no gap). |
+
+### `v1`
+
+Version 1 object header layout. Identified by a version byte of 1 at the start of the header (no signature bytes precede it).
+
+| Field | Description |
+|-------|-------------|
+| `version` | Object header version number. Must be 1. |
+| `res1` | Reserved. Must be zero. |
+| `msg_cnt` | Total number of header messages across all chunks of this object header, including any continuation chunks. |
+| `obj_ref_cnt` | Reference count: the number of hard links pointing to this object. An object is eligible for deletion when this count reaches zero. |
+| `obj_hdr_size` | Size in bytes of the message data in the first object header chunk. The message bytes immediately follow the 16-byte fixed prefix and are accessed via the internal `_msg_chunk` wrapper. |
+| `res2` | Reserved. Must be zero (4 bytes). |
+
+

--- a/docs/generated/superblock.md
+++ b/docs/generated/superblock.md
@@ -1,0 +1,95 @@
+# IV.A.1. Disk Format: Level 0A – File Signatures and Superblock
+
+The superblock contains the information needed to access all other
+HDF5 data structures. It must begin at address 0 within the HDF5 file,
+or at one of the following powers-of-two offsets: 512, 1024, 2048, …
+bytes from the beginning of the file. Libraries that do not write the
+superblock at offset zero must scan those candidate offsets for the
+8-byte signature to locate it.
+
+Four superblock versions are defined. Versions 0 and 1 share the same
+basic layout but version 1 adds a field for the indexed-storage
+internal-node K value. Versions 2 and 3 use a more compact layout that
+replaces the symbol-table root group entry with a plain object header
+address and adds a checksum. Version 3 additionally restricts which
+bits of the consistency flags field may be set.
+
+## `stab_ent`
+
+Symbol table entry for the root group object, embedded directly in superblock versions 0 and 1. Each entry records the object header address, a cache type, and a scratch-pad area whose meaning depends on the cache type.
+
+| Field | Description |
+|-------|-------------|
+| `lnk_nm_off_raw` | Byte offset of the link name within the root local heap's data segment. For the root entry this field is not meaningful and is typically zero. |
+| `ohdr_addr_raw` | File address of the object header for the root group. |
+| `cache_type` | Indicates what is cached in the scratch-pad space. 0 = no cache; 1 = group (B-tree address and heap address are cached); 2 = symbolic link (soft-link target offset is cached). Values 3 and above are reserved. |
+| `res` | Reserved. Must be zero. |
+| `scratch_pad` | 16-byte scratch-pad area. Interpretation is determined by `cache_type`. See variants below. |
+
+### `obj_info`
+
+Present when `cache_type == 1`. Caches the group's B-tree and local heap addresses so that the symbol table can be traversed without first mapping the object header.
+
+| Field | Description |
+|-------|-------------|
+| `btree_addr_raw` | File address of the root B-tree node for the group's symbol table. |
+| `heap_addr_raw` | File address of the local heap containing link names for the group. |
+
+### `slink`
+
+Present when `cache_type == 2`. Stores the byte offset of the symbolic-link target string within the local heap.
+
+### `pad`
+
+Present when `cache_type == 0`. The 16 bytes are undefined and should be ignored.
+
+
+## `superblock`
+
+The root on-disk metadata structure of every HDF5 file.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 8-byte magic number: `0x89 'H' 'D' 'F' 0x0D 0x0A 0x1A 0x0A`. The leading `0x89` sets the high bit so that systems expecting plain ASCII will reject the file; the CR+LF pair detects newline translation; the `0x1A` stops output on MS-DOS `type`; and the final `0x0A` detects trailing newline suppression. |
+| `super_vers` | Superblock format version. Valid values: 0, 1, 2, 3. Versions 0 and 1 use the `v0_v1` layout; versions 2 and 3 use `v2_v3`. |
+
+### `v0_v1`
+
+Layout for superblock versions 0 and 1. Version 1 extends version 0 by adding the `indexed_internal_k` and `res3` fields.
+
+| Field | Description |
+|-------|-------------|
+| `fs_info_vers` | Version of the file free-space storage format. Must be 0. |
+| `root_stab_vers` | Version of the root group symbol table entry format. Must be 0. |
+| `res1` | Reserved. Must be zero. |
+| `shared_hdr_vers` | Version of the shared object header message format. Must be 0. |
+| `sizeof_offsets` | Size in bytes of file addresses (offsets). Typical value: 8. Sets the global `sizeof_offsets` used by all subsequent address fields. |
+| `sizeof_lengths` | Size in bytes of file lengths. Typical value: 8. Sets the global `sizeof_lengths` used by all length fields. |
+| `res2` | Reserved. Must be zero. |
+| `stab_leaf_k` | Half the rank of leaf nodes in the version 1 group B-tree. Must be greater than zero.  The maximum number of entries in a leaf node is `2 * stab_leaf_k`. |
+| `stab_internal_k` | Half the rank of internal nodes in the version 1 group B-tree. Must be greater than zero. |
+| `status_flags` | File consistency flags. Bit 0: file is open for write access and may be inconsistent. Bit 1: file has been verified as consistently closed. |
+| `indexed_internal_k` | Half the rank of internal nodes in the version 1 B-tree used for indexed (chunked) storage. Present only in superblock version 1; must be greater than zero. |
+| `res3` | Reserved. Must be zero. Present only in superblock version 1, immediately following `indexed_internal_k`. |
+| `base_addr_raw` | Absolute byte offset of the start of the HDF5 address space within the physical file. Usually 0. All stored addresses are relative to this base. |
+| `fs_info_addr_raw` | File address of the free-space manager information block, or HADDR_UNDEF (`0xFF…FF`) if free space is not tracked. |
+| `eof_addr_raw` | File address of the first byte beyond all HDF5 data (the logical end-of-file). |
+| `drv_info_addr_raw` | File address of the driver information block, or HADDR_UNDEF if no driver information is present. |
+| `root_stab_ent` | Symbol table entry for the root group (type `stab_ent`). |
+
+### `v2_v3`
+
+Compact layout introduced in superblock version 2. Replaces the symbol-table root entry with a direct object header address and adds a checksum over all preceding superblock bytes. Version 3 restricts the consistency flags to bits 0–2 only.
+
+| Field | Description |
+|-------|-------------|
+| `sizeof_offsets` | Size in bytes of file addresses. Typical value: 8. Sets the global `sizeof_offsets`. |
+| `sizeof_lengths` | Size in bytes of file lengths. Typical value: 8. Sets the global `sizeof_lengths`. |
+| `status_flags` | File consistency flags. In version 2, any bit may be set. In version 3, only bits 0–2 are defined; bits 3–7 must be zero. |
+| `base_addr_raw` | Absolute byte offset of the start of the HDF5 address space. |
+| `ext_addr_raw` | File address of the superblock extension object header, or HADDR_UNDEF if no extension is present. The extension carries optional metadata such as the driver information message. |
+| `eof_addr_raw` | File address of the first byte beyond all HDF5 data. |
+| `root_obj_addr_raw` | File address of the root group object header. |
+| `chksum` | Jenkins lookup3 checksum computed over all preceding superblock bytes (from the signature through `root_obj_addr_raw`). |
+
+

--- a/docs/generated/v1_btree.md
+++ b/docs/generated/v1_btree.md
@@ -1,0 +1,111 @@
+# III.A.1. Disk Format: Level 1A1 – Version 1 B-tree Nodes and Symbol Table Nodes
+
+Version 1 B-trees (on-disk signature 'TREE') are the original indexing
+structure in HDF5. Two node types are defined:
+
+- **Node type 0** — group (symbol table) B-tree. Used to index the
+  members of a group stored in the legacy symbol-table format. Leaf
+  children are Symbol Table Nodes (signature 'SNOD').
+- **Node type 1** — raw-data chunk B-tree. Used to index the chunks
+  of a chunked dataset. At level 0 each child pointer addresses a
+  chunk payload directly.
+
+The on-disk key/child layout for a node with `entries_used = n` is:
+
+```
+K_0  C_0  K_1  C_1  ...  K_{n-1}  C_{n-1}  K_n
+```
+
+Each node is sized to hold up to `2K` entries (where K is the relevant
+B-tree K value from the superblock). Only the first `entries_used` pairs
+are valid; unused capacity beyond that is not mapped by these pickles.
+
+Before mapping a type-1 node, call `set_bt1_ndims(n)` where n is the
+dataset dimensionality plus one. Use `print_v1_btree(addr#B, 0)` to
+recursively print the full tree.
+
+## `bt1_key0`
+
+Key for a type-0 (group symbol table) B-tree node. Bounds a range of link names by their offset in the group's local heap.
+
+| Field | Description |
+|-------|-------------|
+| `name_off_raw` | Byte offset into the local heap of the first link name in the range covered by this key (`sizeof_lengths` bytes, little-endian). |
+
+
+## `bt1_key1`
+
+Key for a type-1 (raw-data chunk) B-tree node. Identifies the logical position of a chunk in dataset space and records its on-disk size.
+
+| Field | Description |
+|-------|-------------|
+| `chunk_size` | Size in bytes of the chunk payload as stored on disk (after any filter pipeline). |
+| `filter_mask` | Pipeline skip mask. Bit i set means filter i was not applied to this chunk (e.g. the chunk was already in the desired form). |
+| `chunk_offsets` | Array of `global_bt1_ndims` uint64 logical dimension offsets (0-based) locating the chunk in dataset space. The last entry is always zero per the HDF5 specification and is used as a sentinel. |
+
+
+## `bt1_pair0`
+
+A single key/child pair for a type-0 (group) B-tree node. Each valid body slot is one of these; a trailing key follows the last pair.
+
+| Field | Description |
+|-------|-------------|
+| `key` | The `bt1_key0` key bounding the left edge of this child's range. |
+| `child_raw` | File address of the child (`sizeof_offsets` bytes). At `node_level == 0` this points to a Symbol Table Node (SNOD); at higher levels it points to another `v1_btree` node. |
+
+
+## `bt1_pair1`
+
+A single key/child pair for a type-1 (raw-data chunk) B-tree node.
+
+| Field | Description |
+|-------|-------------|
+| `key` | The `bt1_key1` key identifying this chunk's logical position. |
+| `child_raw` | File address of the child (`sizeof_offsets` bytes). At `node_level == 0` this is the file address of the chunk data payload; at higher levels it is another `v1_btree` node. |
+
+
+## `v1_btree`
+
+Version 1 B-tree node (signature 'TREE'). A single on-disk record that acts as either an internal node or a leaf, depending on `node_level`. Nodes at level 0 are leaves; their children are either chunk data (type 1) or Symbol Table Nodes (type 0). A third union arm `unknown` (six raw bytes) is a fallback for invalid node types and is never written by a conforming implementation.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'T' 'R' 'E' 'E'. Must match exactly. |
+| `node_type` | Node type: 0 = group (symbol table), 1 = raw-data chunks. |
+| `node_level` | Height of this node in the tree. 0 = leaf; children at level > 0 are also `v1_btree` nodes. The root node's level equals the height of the tree minus one. |
+| `entries_used` | Number of valid key/child pairs stored in this node. Always ≤ `2 × K` where K is the relevant superblock B-tree K value. |
+| `left_sib_raw` | File address of the left sibling node at the same tree level (`sizeof_offsets` bytes). HADDR_UNDEF if this is the leftmost node at this level. |
+| `right_sib_raw` | File address of the right sibling node at the same level. HADDR_UNDEF if this is the rightmost node. |
+
+### `type0`
+
+Node body for a type-0 (group symbol table) node.
+
+| Field | Description |
+|-------|-------------|
+| `pairs` | Array of `entries_used` `bt1_pair0` key/child pairs in ascending key order. |
+| `final_key` | Trailing `bt1_key0` key bounding the right edge of the last child's range. |
+
+### `type1`
+
+Node body for a type-1 (raw-data chunk) node.
+
+| Field | Description |
+|-------|-------------|
+| `pairs` | Array of `entries_used` `bt1_pair1` key/child pairs in ascending chunk-offset order. |
+| `final_key` | Trailing `bt1_key1` key bounding the right edge of the last chunk. |
+
+
+## `snod_node`
+
+Symbol Table Node (signature 'SNOD'). Leaf node pointed to by the child pointers of a type-0 B-tree leaf. Each SNOD holds between 0 and `2 × stab_leaf_k` symbol table entries; `num_symbols` records how many are valid. The `stab_ent` type is defined in `superblock.pk`.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'S' 'N' 'O' 'D'. Must match exactly. |
+| `version` | Symbol table node version. Must be 1. |
+| `res` | Reserved. Must be zero. |
+| `num_symbols` | Number of valid `stab_ent` entries in `entries`. |
+| `entries` | Array of `num_symbols` symbol table entries of type `stab_ent` (see `superblock.pk`). Each entry records a link name offset, an object header address, a cache type, and a scratch-pad area. |
+
+

--- a/docs/generated/v2_btree.md
+++ b/docs/generated/v2_btree.md
@@ -1,0 +1,246 @@
+# III.A.2. Disk Format: Level 1B – Version 2 B-tree Nodes
+
+Version 2 B-trees are a self-describing, checksummed replacement for
+the version 1 B-tree used for new indexing needs introduced in HDF5
+1.8. Three on-disk structures are defined:
+
+- **Header** (signature 'BTHD') — one per B-tree; records the record
+  type, node geometry, depth, and root node address.
+- **Leaf node** (signature 'BTLF') — stores up to the configured
+  maximum records with no child pointers.
+- **Internal node** (signature 'BTIN') — stores records interleaved
+  with child pointers, each carrying the record count of the child
+  node and, for nodes deeper than level 1, the total record count of
+  the child's subtree.
+
+Eleven record types are defined, covering: huge-object tracking
+(types 1–4), indexed-group link names (types 5–6), shared object
+header messages (type 7), indexed-attribute names and creation order
+(types 8–9), and non-filtered and filtered dataset chunk addresses
+(types 10–11).
+
+The global variables `global_bt2_*` must be set correctly before
+mapping any node. `print_v2_btree(addr#B)` handles this automatically
+by reading the header first.
+
+## `v2_btree_hdr`
+
+Version 2 B-tree header (signature 'BTHD'). Describes the geometry of the entire B-tree. Mapping this struct sets the global parameters `global_bt2_type`, `global_bt2_record_size`, `global_bt2_node_size`, and `global_bt2_depth` via constraint side-effects, so subsequent node mappings require no additional setter calls.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'B' 'T' 'H' 'D'. Must match exactly. |
+| `version` | Header format version. Must be 0. |
+| `record_type` | Record type identifier (1–11). Determines which `bt2_rec_type*` struct to use for records. |
+| `node_size` | Size in bytes of each B-tree node (leaf or internal). All nodes have the same size. |
+| `record_size` | Size in bytes of each record within a node. |
+| `depth` | Tree depth. 0 means the root is a leaf node; > 0 means the root is an internal node. |
+| `split_percent` | Node occupancy percentage above which a node is split (typically 100). |
+| `merge_percent` | Node occupancy percentage below which two sibling nodes are merged (typically 40). |
+| `root_addr_raw` | File address of the root node (`sizeof_offsets` bytes). |
+| `num_root_records` | Number of records currently stored in the root node. |
+| `total_nrec_raw` | Total number of records across all nodes in the B-tree (`sizeof_lengths` bytes). |
+| `chksum` | Jenkins lookup3 checksum of all preceding header bytes. |
+
+
+## `bt2_rec_type1`
+
+Record type 1 — indirectly accessed, non-filtered huge object. The object is tracked in the fractal heap and carries a unique object ID.
+
+| Field | Description |
+|-------|-------------|
+| `huge_obj_addr_raw` | File address of the huge object (`sizeof_offsets` bytes). |
+| `huge_obj_len_raw` | Size in bytes of the huge object (`sizeof_lengths` bytes). |
+| `huge_obj_id_raw` | Unique huge-object ID assigned by the heap (`sizeof_lengths` bytes). |
+
+
+## `bt2_rec_type2`
+
+Record type 2 — indirectly accessed, filtered huge object. Like type 1 but the data has passed through the filter pipeline; carries the unfiltered size and a filter skip mask.
+
+| Field | Description |
+|-------|-------------|
+| `huge_obj_addr_raw` | File address of the filtered huge object (`sizeof_offsets` bytes). |
+| `huge_obj_len_raw` | On-disk (filtered) size in bytes (`sizeof_lengths` bytes). |
+| `filter_mask` | Filter pipeline skip mask (same semantics as `bt1_key1.filter_mask`). |
+| `huge_obj_mem_size_raw` | Unfiltered (in-memory) size in bytes (`sizeof_lengths` bytes). |
+| `huge_obj_id_raw` | Unique huge-object ID (`sizeof_lengths` bytes). |
+
+
+## `bt2_rec_type3`
+
+Record type 3 — directly accessed, non-filtered huge object. The object is accessed by file address without heap tracking, so there is no unique ID field.
+
+| Field | Description |
+|-------|-------------|
+| `huge_obj_addr_raw` | File address of the huge object (`sizeof_offsets` bytes). |
+| `huge_obj_len_raw` | Size in bytes of the huge object (`sizeof_lengths` bytes). |
+
+
+## `bt2_rec_type4`
+
+Record type 4 — directly accessed, filtered huge object. Like type 3 but includes filter metadata; no unique ID field.
+
+| Field | Description |
+|-------|-------------|
+| `huge_obj_addr_raw` | File address of the filtered huge object (`sizeof_offsets` bytes). |
+| `huge_obj_len_raw` | On-disk (filtered) size in bytes (`sizeof_lengths` bytes). |
+| `filter_mask` | Filter pipeline skip mask. |
+| `huge_obj_mem_size_raw` | Unfiltered (in-memory) size in bytes (`sizeof_lengths` bytes). |
+
+
+## `bt2_rec_type5`
+
+Record type 5 — link name in a creation-name-ordered indexed group. Provides fast lookup of a link by the hash of its name.
+
+| Field | Description |
+|-------|-------------|
+| `name_hash` | Jenkins lookup3 hash of the link name (used as the B-tree key). |
+| `heap_id_raw` | 7-byte fractal heap object ID for the link record. |
+
+
+## `bt2_rec_type6`
+
+Record type 6 — link name in a creation-order-indexed group. Provides fast lookup of a link by its creation order value.
+
+| Field | Description |
+|-------|-------------|
+| `creation_order` | Link creation order value (B-tree key). |
+| `heap_id_raw` | 7-byte fractal heap object ID for the link record. |
+
+
+## `bt2_rec_type7_sub0`
+
+Record type 7, sub-type 0 — shared message stored in the fractal heap. Identified at runtime by reading the first byte of the record: `message_location == 0` selects this sub-type.
+
+| Field | Description |
+|-------|-------------|
+| `message_location` | Storage location indicator. Must be 0 for this sub-type (message is in the fractal heap). |
+| `hash` | Jenkins lookup3 hash of the shared message payload (B-tree key). |
+| `reference_count` | Number of object headers that reference this shared message. |
+| `heap_id_raw` | 8-byte fractal heap object ID for the shared message. |
+
+
+## `bt2_rec_type7_sub1`
+
+Record type 7, sub-type 1 — shared message stored inline in an object header. Identified by `message_location == 1`.
+
+| Field | Description |
+|-------|-------------|
+| `message_location` | Storage location indicator. Must be 1 for this sub-type (message is in an object header). |
+| `hash` | Jenkins lookup3 hash of the shared message payload (B-tree key). |
+| `message_type` | Object header message type of the shared message. |
+| `obj_hdr_index` | Index of the message within its containing object header. |
+| `obj_hdr_addr_raw` | File address of the object header containing the shared message (`sizeof_offsets` bytes). |
+
+
+## `bt2_rec_type8`
+
+Record type 8 — attribute name for name-ordered indexed attributes. Provides fast lookup of an attribute by name hash and creation order.
+
+| Field | Description |
+|-------|-------------|
+| `heap_id_raw` | 8-byte fractal heap object ID for the attribute record. |
+| `message_flags` | Object header message flags for this attribute (same bit definitions as `msg_prefix.msg_flags`). |
+| `creation_order` | Attribute creation order value. |
+| `name_hash` | Jenkins lookup3 hash of the attribute name (primary B-tree key). |
+
+
+## `bt2_rec_type9`
+
+Record type 9 — attribute name for creation-order-indexed attributes. Like type 8 but without the name hash; creation order is the key.
+
+| Field | Description |
+|-------|-------------|
+| `heap_id_raw` | 8-byte fractal heap object ID for the attribute record. |
+| `message_flags` | Object header message flags for this attribute. |
+| `creation_order` | Attribute creation order value (B-tree key). |
+
+
+## `bt2_rec_type10`
+
+Record type 10 — non-filtered dataset chunk address. Used as the chunk index for datasets whose chunks pass through no filter pipeline. The number of `scaled_offsets` entries equals the dataset dimensionality; before mapping, set `global_bt2_ndims` accordingly or call `print_v2_btree` which derives it automatically.
+
+| Field | Description |
+|-------|-------------|
+| `chunk_addr_raw` | File address of the chunk data payload (`sizeof_offsets` bytes). |
+| `scaled_offsets` | Array of `global_bt2_ndims` uint64 scaled chunk position values. Each entry is the logical dimension offset divided by the chunk dimension size, giving the chunk's coordinates in chunk-index space (B-tree key). |
+
+
+## `bt2_rec_type11`
+
+Record type 11 — filtered dataset chunk address. Like type 10 but includes the on-disk (filtered) chunk size and a filter skip mask.
+
+| Field | Description |
+|-------|-------------|
+| `chunk_addr_raw` | File address of the filtered chunk data payload (`sizeof_offsets` bytes). |
+| `chunk_size_raw` | On-disk (filtered) chunk size in bytes (`sizeof_lengths` bytes). |
+| `filter_mask` | Filter pipeline skip mask for this chunk. |
+| `scaled_offsets` | Array of `global_bt2_ndims` uint64 scaled chunk position values (B-tree key). |
+
+
+## `bt2_raw_record`
+
+Generic fallback record used when the record type is unknown or unhandled. Stores the raw bytes of the record so they can be inspected without type-specific decoding.
+
+| Field | Description |
+|-------|-------------|
+| `data` | Raw record bytes (`global_bt2_record_size` bytes). |
+
+
+## `bt2_child_ptr_d1`
+
+Child pointer in a depth-1 internal node (one whose children are leaf nodes). Contains the child's file address and the number of records directly stored in that child. No subtree record count is needed because the child is a leaf.
+
+| Field | Description |
+|-------|-------------|
+| `child_addr_raw` | File address of the child node (`sizeof_offsets` bytes). |
+| `nrec_in_child_raw` | Number of records stored in the child node (`global_bt2_nrec_in_node_bytes` bytes). Use `set_bt2_nrec_size_from_hdr` to compute the correct byte width from the header. |
+
+
+## `bt2_child_ptr_dn`
+
+Child pointer in a depth > 1 internal node (one whose children are themselves internal nodes). Adds a subtree record count field that records the total number of records in the child's entire subtree.
+
+| Field | Description |
+|-------|-------------|
+| `child_addr_raw` | File address of the child node (`sizeof_offsets` bytes). |
+| `nrec_in_child_raw` | Number of records directly in the child node (`global_bt2_nrec_in_node_bytes` bytes). |
+| `nrec_in_subtree_raw` | Total records in the child's subtree including all descendant nodes (`global_bt2_nrec_in_subtree_bytes` bytes). Use `set_bt2_nrec_subtree_size_from_hdr` to compute the correct byte width. |
+
+
+## `v2_btree_leaf`
+
+Version 2 B-tree leaf node (signature 'BTLF'). Contains up to the configured maximum number of records and no child pointers. Before mapping, set `global_bt2_nrec` to the record count for this node (from `hdr.num_root_records` for the root, or from the parent's `nrec_in_child_raw` for non-root nodes).
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'B' 'T' 'L' 'F'. Must match exactly. |
+| `version` | Leaf node format version. Must be 0. |
+| `record_type` | Record type identifier (mirrors `v2_btree_hdr.record_type`). |
+| `records` | Array of `global_bt2_nrec` raw records, each `global_bt2_record_size` bytes. Use `print_v2_btree_record_at` to decode individual records according to `record_type`. |
+| `chksum` | Jenkins lookup3 checksum of all preceding node bytes. |
+
+
+## `v2_btree_internal`
+
+Version 2 B-tree internal node (signature 'BTIN'). Stores records interleaved with `global_bt2_nrec + 1` child pointers. The child- pointer layout depends on the node's depth: depth-1 nodes use `bt2_child_ptr_d1`; deeper nodes use `bt2_child_ptr_dn`. Before mapping, set `global_bt2_depth` and `global_bt2_nrec` to the values for this node.
+
+| Field | Description |
+|-------|-------------|
+| `signature` | 4-byte signature: 'B' 'T' 'I' 'N'. Must match exactly. |
+| `version` | Internal node format version. Must be 0. |
+| `record_type` | Record type identifier (mirrors `v2_btree_hdr.record_type`). |
+| `records` | Array of `global_bt2_nrec` raw records in ascending key order. |
+| `children` | Union of `global_bt2_nrec + 1` child pointers; layout selected by tree depth. |
+| `chksum` | Jenkins lookup3 checksum of all preceding node bytes. |
+
+### `d1`
+
+Child-pointer array for a depth-1 internal node (children are leaves). Each pointer is a `bt2_child_ptr_d1` carrying the child address and record count only.
+
+### `dn`
+
+Child-pointer array for a depth > 1 internal node (children are internal nodes). Each pointer is a `bt2_child_ptr_dn` carrying the child address, node record count, and subtree record count.
+
+

--- a/docs/spec/earray.yml
+++ b/docs/spec/earray.yml
@@ -1,0 +1,294 @@
+pickle: earray.pk
+section: "C.IV. Extensible Array Chunk Index"
+intro: |
+  The Extensible Array (EA) is a chunk index used for datasets with
+  exactly one unlimited dimension.  Unlike the Fixed Array it can grow
+  in one direction without rebuilding the entire index.
+
+  The structure is a four-level hierarchy:
+
+  ```
+  Header (EAHD)
+    └─ Index Block (EAIB)
+         ├─ direct elements          (first idx_blk_elmts chunks)
+         ├─ direct data block addresses   (first iblk_nsblks secondary groups)
+         └─ secondary block addresses     (remaining secondary groups)
+              └─ Secondary Block (EASB)
+                   └─ Data Block addresses
+                        └─ Data Block (EADB)
+                             └─ [Data Block Pages]  (when paged)
+  ```
+
+  Data blocks are organised into *secondary block groups* indexed by u = 0, 1, 2, …:
+
+  | Group u | Data blocks in group | Elements per data block         |
+  |---------|----------------------|---------------------------------|
+  | u       | 2^(u/2)              | 2^((u+1)/2) × data_blk_min_elmts |
+
+  The first `iblk_nsblks = 2 × log2(sup_blk_min_data_ptrs)` secondary
+  block groups have their data block addresses stored directly in the
+  index block.  The remaining groups are managed via separate Secondary
+  Block structures.
+
+  **Paging:** when a data block's element count exceeds
+  `2^max_dblk_page_nelmts_bits`, elements are stored in separate data
+  block pages appended immediately after the data block prefix in the
+  file.  All pages within one data block hold the same number of elements.
+
+  **Client IDs:**
+
+  | ID | Name                   | Element layout                                         |
+  |----|------------------------|--------------------------------------------------------|
+  | 0  | H5EA_CLS_CHUNK_ID      | `sizeof_offsets`-byte chunk file address               |
+  | 1  | H5EA_CLS_FILT_CHUNK_ID | chunk address + filtered size + 4-byte filter mask    |
+
+  Use `print_ea(addr#B)` to map the header, print it and the index block,
+  and recursively walk all reachable data blocks and secondary blocks.
+
+types:
+
+  # ── Element types ─────────────────────────────────────────────────────────
+
+  ea_chunk_elem:
+    desc: "One element for a non-filtered chunk (client ID 0). Contains only the chunk's file address."
+    fields:
+      addr_raw:
+        desc: "File address of the chunk data (`sizeof_offsets` bytes). HADDR_UNDEF if the chunk has not been written."
+
+  ea_filt_chunk_elem:
+    desc: >-
+      One element for a filtered chunk (client ID 1). Records the chunk
+      address, its on-disk (post-filter) size, and the filter pipeline
+      skip mask.
+    fields:
+      addr_raw:
+        desc: "File address of the filtered chunk data (`sizeof_offsets` bytes)."
+      chunk_size_raw:
+        desc: >-
+          On-disk (filtered) size of the chunk in bytes
+          (`global_ea_chunk_size_len` bytes =
+          `raw_elmt_size − sizeof_offsets − 4`).
+      filter_mask:
+        desc: "Filter pipeline skip mask. Bit i set means filter i was not applied to this chunk."
+
+  ea_element:
+    desc: >-
+      Dispatch union that resolves to the correct element layout based on
+      `global_ea_client_id` at mapping time.
+    variants:
+      non_filtered:
+        desc: "Active when `global_ea_client_id == 0`. Wraps `ea_chunk_elem`."
+      filtered:
+        desc: "Active when `global_ea_client_id == 1`. Wraps `ea_filt_chunk_elem`."
+      testing:
+        desc: >-
+          Active when `global_ea_client_id == 2`. Wraps `ea_chunk_elem`.
+          Added for compatibility with internal EA test files only; not
+          part of the public format specification.
+
+  # ── Header ────────────────────────────────────────────────────────────────
+
+  ea_hdr:
+    desc: >-
+      Extensible Array header (signature 'EAHD'). Stores the element
+      type and all structural parameters of the array. Mapping this struct
+      sets all `global_ea_*` parameters via constraint side-effects,
+      including the derived counts `iblk_nsblks`, `ndblk_addrs`,
+      `nsblk_addrs`, `arr_off_size`, and `dblk_page_nelmts`.
+    fields:
+      signature:
+        desc: "4-byte signature: 'E' 'A' 'H' 'D'. Must match exactly."
+      version:
+        desc: "Header format version. Must be 0."
+      client_id:
+        desc: "Element class: 0 = non-filtered chunk addresses, 1 = filtered chunk addresses."
+      raw_elmt_size:
+        desc: "On-disk size in bytes of each array element."
+      max_nelmts_bits:
+        desc: >-
+          Log₂ of the maximum number of elements the array can hold.
+          Determines `arr_off_size = ⌈max_nelmts_bits / 8⌉`, the byte
+          width used to encode array element offsets.
+      idx_blk_elmts:
+        desc: >-
+          Number of elements stored directly in the index block (the
+          lowest-index chunks are stored here to avoid allocating data
+          blocks for small datasets).
+      data_blk_min_elmts:
+        desc: >-
+          Minimum number of elements per data block (must be a power of
+          two). Controls the element count per data block via
+          `dblk_nelmts[u] = 2^((u+1)/2) × data_blk_min_elmts`.
+      sup_blk_min_data_ptrs:
+        desc: >-
+          Minimum number of data block pointers in a secondary block
+          (must be a power of two). Controls the layout of the index
+          block via `iblk_nsblks = 2 × log2(sup_blk_min_data_ptrs)`.
+      max_dblk_page_nelmts_bits:
+        desc: >-
+          Log₂ of the maximum number of elements per data block page.
+          0 means paging is disabled.
+      nsuper_blks_raw:
+        desc: "Total number of secondary blocks allocated (`sizeof_lengths` bytes)."
+      super_blk_size_raw:
+        desc: "Total bytes consumed by all secondary blocks (`sizeof_lengths` bytes)."
+      ndata_blks_raw:
+        desc: "Total number of data blocks allocated (`sizeof_lengths` bytes)."
+      data_blk_size_raw:
+        desc: "Total bytes consumed by all data blocks (`sizeof_lengths` bytes)."
+      max_idx_set_raw:
+        desc: "Highest element index that has been set (`sizeof_lengths` bytes)."
+      nelmts_raw:
+        desc: "Total number of elements currently stored in the array (`sizeof_lengths` bytes)."
+      idx_blk_addr_raw:
+        desc: "File address of the index block (`sizeof_offsets` bytes)."
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding header bytes."
+
+  # ── Index Block ───────────────────────────────────────────────────────────
+
+  ea_iblock:
+    desc: >-
+      Extensible Array index block (signature 'EAIB'). Central dispatch
+      structure. Holds the first `idx_blk_elmts` elements directly, then
+      `ndblk_addrs` data block addresses for the first `iblk_nsblks`
+      secondary block groups, then `nsblk_addrs` secondary block addresses
+      for the remaining groups.
+    fields:
+      signature:
+        desc: "4-byte signature: 'E' 'A' 'I' 'B'. Must match exactly."
+      version:
+        desc: "Index block format version. Must be 0."
+      client_id:
+        desc: "Element class (mirrors `ea_hdr.client_id`)."
+      hdr_addr_raw:
+        desc: "Back-pointer: file address of the Extensible Array header (`sizeof_offsets` bytes)."
+      elements:
+        desc: >-
+          Array of `global_ea_idx_blk_elmts` elements stored inline
+          (type `ea_element`). These are the lowest-index chunks and
+          are accessed without following any data block pointer.
+      dblk_addrs:
+        desc: >-
+          `global_ea_ndblk_addrs × sizeof_offsets` byte array of data
+          block file addresses. Entries are grouped by secondary block
+          group u; within group u there are `2^(u/2)` addresses.
+          HADDR_UNDEF entries indicate unallocated data blocks.
+      sblk_addrs:
+        desc: >-
+          `global_ea_nsblk_addrs × sizeof_offsets` byte array of
+          secondary block file addresses for groups u = iblk_nsblks …
+          nsblks−1. HADDR_UNDEF entries indicate unallocated secondary
+          blocks.
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding index block bytes."
+
+  # ── Secondary Block ───────────────────────────────────────────────────────
+
+  ea_sblock:
+    desc: >-
+      Extensible Array secondary block (signature 'EASB'). Manages the
+      data blocks for one secondary block group u. Before mapping, call
+      `set_ea_sblock_idx(u)` to configure `global_ea_sblk_ndblks`,
+      `global_ea_sblk_dblk_nelmts`, `global_ea_sblk_dblk_npages`, and
+      `global_ea_sblk_total_page_init_size`.
+    fields:
+      signature:
+        desc: "4-byte signature: 'E' 'A' 'S' 'B'. Must match exactly."
+      version:
+        desc: "Secondary block format version. Must be 0."
+      client_id:
+        desc: "Element class (mirrors `ea_hdr.client_id`)."
+      hdr_addr_raw:
+        desc: "Back-pointer: file address of the Extensible Array header (`sizeof_offsets` bytes)."
+      block_off_raw:
+        desc: >-
+          Array-element offset of the first element reachable via this
+          secondary block (`global_ea_arr_off_size` bytes =
+          ⌈max_nelmts_bits / 8⌉).
+      page_init_flags:
+        desc: >-
+          Page-initialisation bitmask for the data blocks managed by
+          this secondary block (`global_ea_sblk_total_page_init_size`
+          bytes = `ndblks × ⌈dblk_npages / 8⌉`). Zero-length when the
+          data blocks in this group are not paged.
+      dblk_addrs:
+        desc: >-
+          `global_ea_sblk_ndblks × sizeof_offsets` byte array of data
+          block file addresses for this secondary block group. HADDR_UNDEF
+          entries indicate unallocated data blocks.
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding secondary block bytes."
+
+  # ── Data Block ────────────────────────────────────────────────────────────
+
+  ea_dblock_nopaged:
+    desc: >-
+      Extensible Array data block, non-paged layout (signature 'EADB').
+      Used when `global_ea_dblk_npages == 0`. All `global_ea_dblk_nelmts`
+      elements are stored inline after the block header. Before mapping,
+      call `set_ea_dblock(nelmts)` with the element count for this
+      particular data block.
+    fields:
+      signature:
+        desc: "4-byte signature: 'E' 'A' 'D' 'B'. Must match exactly."
+      version:
+        desc: "Data block format version. Must be 0."
+      client_id:
+        desc: "Element class (mirrors `ea_hdr.client_id`)."
+      hdr_addr_raw:
+        desc: "Back-pointer: file address of the Extensible Array header (`sizeof_offsets` bytes)."
+      block_off_raw:
+        desc: "Array-element offset of the first element in this data block (`global_ea_arr_off_size` bytes)."
+      elements:
+        desc: "Array of `global_ea_dblk_nelmts` inline elements (type `ea_element`)."
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding data block bytes."
+
+  ea_dblock_paged:
+    desc: >-
+      Extensible Array data block, paged layout (signature 'EADB'). Used
+      when `global_ea_dblk_npages > 0`. Captures only the block prefix;
+      elements are in `ea_dblk_page` records that follow the prefix
+      consecutively in the file. Before mapping, call
+      `set_ea_dblock(nelmts)`.
+    fields:
+      signature:
+        desc: "4-byte signature: 'E' 'A' 'D' 'B'. Must match exactly."
+      version:
+        desc: "Data block format version. Must be 0."
+      client_id:
+        desc: "Element class (mirrors `ea_hdr.client_id`)."
+      hdr_addr_raw:
+        desc: "Back-pointer: file address of the Extensible Array header (`sizeof_offsets` bytes)."
+      block_off_raw:
+        desc: "Array-element offset of the first element in this data block (`global_ea_arr_off_size` bytes)."
+      chksum:
+        desc: "Jenkins lookup3 checksum of all bytes from `signature` through `block_off_raw`."
+
+  ea_dblock:
+    desc: >-
+      Top-level Extensible Array data block dispatch union (signature
+      'EADB'). Selects `ea_dblock_paged` when `global_ea_dblk_npages > 0`,
+      otherwise `ea_dblock_nopaged`. Map with
+      `set_ea_dblock(nelmts)` then `var db = ea_dblock @ addr#B`.
+    variants:
+      paged:
+        desc: "Paged prefix layout. Active when `global_ea_dblk_npages > 0`."
+      nopaged:
+        desc: "Inline element layout. Active when `global_ea_dblk_npages == 0`."
+
+  # ── Data Block Page ───────────────────────────────────────────────────────
+
+  ea_dblk_page:
+    desc: >-
+      Extensible Array data block page. No on-disk signature; pages are
+      appended consecutively to a paged data block prefix. Every page
+      within one data block holds exactly `global_ea_dblk_page_nelmts`
+      elements (data block sizes always divide evenly into pages). Map
+      with `var pg = ea_dblk_page @ page_offset#B`.
+    fields:
+      elements:
+        desc: "Array of `global_ea_dblk_page_nelmts` elements (type `ea_element`)."
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding page bytes."

--- a/docs/spec/farray.yml
+++ b/docs/spec/farray.yml
@@ -1,0 +1,175 @@
+pickle: farray.pk
+section: "C.III. Fixed Array Chunk Index"
+intro: |
+  The Fixed Array (FA) is a chunk index used for datasets with a fixed
+  number of chunks — i.e. datasets whose every dimension is either fixed
+  in size or has at most one unlimited dimension that never grows beyond
+  a single chunk in that dimension.  It provides O(1) access to any chunk
+  by logical index.
+
+  Two on-disk structures are defined:
+
+  - **Header** (signature 'FAHD') — one per dataset; stores element
+    geometry and the address of the data block.
+  - **Data Block** (signature 'FADB') — holds the actual chunk addresses
+    (and, for filtered datasets, per-chunk metadata).
+
+  **Paging:** when the element count exceeds `2^max_dblk_page_nelmts_bits`
+  the data block is split into fixed-size pages stored consecutively after
+  the data block prefix in the file.  The prefix then records only the
+  page-initialisation bitmask; elements live in `fa_dblk_page` records.
+  When `max_dblk_page_nelmts_bits == 0` or the element count is small
+  enough, all elements are stored directly in the data block (`fa_dblock_nopaged`).
+
+  **Client IDs:**
+
+  | ID | Name                  | Element layout                                          |
+  |----|-----------------------|---------------------------------------------------------|
+  | 0  | H5FA_CLS_CHUNK_ID     | `sizeof_offsets`-byte chunk file address                |
+  | 1  | H5FA_CLS_FILT_CHUNK_ID| chunk address + filtered size + 4-byte filter mask     |
+
+  Use `print_fa(addr#B)` to map the header, print it, and recursively
+  print the data block and all pages.
+
+types:
+
+  # ── Element types ────────────────────────────────────────────────────────
+
+  fa_chunk_elem:
+    desc: "One element for a non-filtered chunk (client ID 0). Contains only the chunk's file address."
+    fields:
+      addr_raw:
+        desc: "File address of the chunk data (`sizeof_offsets` bytes). HADDR_UNDEF if the chunk has not been written."
+
+  fa_filt_chunk_elem:
+    desc: >-
+      One element for a filtered chunk (client ID 1). Stores the chunk
+      address, its on-disk (post-filter) size, and the filter pipeline
+      skip mask.
+    fields:
+      addr_raw:
+        desc: "File address of the filtered chunk data (`sizeof_offsets` bytes)."
+      chunk_size_raw:
+        desc: >-
+          On-disk (filtered) size of the chunk in bytes
+          (`global_fa_chunk_size_len` bytes =
+          `raw_elmt_size − sizeof_offsets − 4`).
+      filter_mask:
+        desc: "Filter pipeline skip mask. Bit i set means filter i was not applied to this chunk."
+
+  fa_element:
+    desc: >-
+      Dispatch union that resolves to the correct element layout based on
+      `global_fa_client_id` at mapping time. Both arms have the same
+      on-disk footprint (`raw_elmt_size` bytes) for a given header.
+    variants:
+      non_filtered:
+        desc: "Active when `global_fa_client_id == 0`. Wraps `fa_chunk_elem`."
+      filtered:
+        desc: "Active when `global_fa_client_id == 1`. Wraps `fa_filt_chunk_elem`."
+
+  # ── Header ───────────────────────────────────────────────────────────────
+
+  fa_hdr:
+    desc: >-
+      Fixed Array header (signature 'FAHD'). Describes the element type
+      and geometry of the entire fixed array. Mapping this struct
+      automatically sets all `global_fa_*` parameters via constraint
+      side-effects so that the data block and pages can be mapped
+      immediately afterwards.
+    fields:
+      signature:
+        desc: "4-byte signature: 'F' 'A' 'H' 'D'. Must match exactly."
+      version:
+        desc: "Header format version. Must be 0."
+      client_id:
+        desc: "Element class: 0 = non-filtered chunk addresses, 1 = filtered chunk addresses."
+      raw_elmt_size:
+        desc: >-
+          On-disk size in bytes of each array element. For client ID 0
+          this equals `sizeof_offsets`; for client ID 1 it equals
+          `sizeof_offsets + chunk_size_len + 4`.
+      max_dblk_page_nelmts_bits:
+        desc: >-
+          Log₂ of the maximum number of elements per data block page.
+          0 means paging is disabled and all elements are stored inline
+          in the data block.
+      nelmts_raw:
+        desc: "Total number of elements (chunks) indexed by this fixed array (`sizeof_lengths` bytes)."
+      dblk_addr_raw:
+        desc: "File address of the associated data block (`sizeof_offsets` bytes)."
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding header bytes."
+
+  # ── Data Block Page ───────────────────────────────────────────────────────
+
+  fa_dblk_page:
+    desc: >-
+      Fixed Array data block page. Only present when paging is active
+      (`global_fa_npages > 0`). Pages have no on-disk signature; they
+      are stored consecutively immediately after the data block prefix.
+      All full pages hold `global_fa_dblk_page_nelmts` elements; the
+      final page may hold fewer (`global_fa_last_page_nelmts`). Override
+      `global_fa_page_nelmts` with `set_fa_page_nelmts(n)` before
+      mapping the last page, then restore it with `reset_fa_page_nelmts`.
+    fields:
+      elements:
+        desc: "Array of `global_fa_page_nelmts` elements (type `fa_element`)."
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding page bytes."
+
+  # ── Data Block ────────────────────────────────────────────────────────────
+
+  fa_dblock_nopaged:
+    desc: >-
+      Fixed Array data block, non-paged layout (signature 'FADB').
+      Used when `global_fa_npages == 0`. All `global_fa_nelmts` elements
+      are stored inline in the `elements` array.
+    fields:
+      signature:
+        desc: "4-byte signature: 'F' 'A' 'D' 'B'. Must match exactly."
+      version:
+        desc: "Data block format version. Must be 0."
+      client_id:
+        desc: "Element class (mirrors `fa_hdr.client_id`)."
+      hdr_addr_raw:
+        desc: "Back-pointer: file address of the Fixed Array header (`sizeof_offsets` bytes)."
+      elements:
+        desc: "Array of `global_fa_nelmts` inline elements (type `fa_element`)."
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding data block bytes."
+
+  fa_dblock_paged:
+    desc: >-
+      Fixed Array data block, paged layout (signature 'FADB'). Used when
+      `global_fa_npages > 0`. This struct captures only the prefix;
+      the actual elements are stored in `fa_dblk_page` records that
+      follow immediately in the file. The page-initialisation bitmask
+      tracks which pages have been written.
+    fields:
+      signature:
+        desc: "4-byte signature: 'F' 'A' 'D' 'B'. Must match exactly."
+      version:
+        desc: "Data block format version. Must be 0."
+      client_id:
+        desc: "Element class (mirrors `fa_hdr.client_id`)."
+      hdr_addr_raw:
+        desc: "Back-pointer: file address of the Fixed Array header (`sizeof_offsets` bytes)."
+      page_init_flags:
+        desc: >-
+          Page-initialisation bitmask (`global_fa_dblk_page_init_size`
+          bytes = ⌈npages / 8⌉). Bit i is set when page i has been
+          written to disk.
+      chksum:
+        desc: "Jenkins lookup3 checksum of all bytes from `signature` through `page_init_flags`."
+
+  fa_dblock:
+    desc: >-
+      Top-level Fixed Array data block dispatch union (signature 'FADB').
+      Selects `fa_dblock_paged` when `global_fa_npages > 0`, otherwise
+      `fa_dblock_nopaged`. Map with `var db = fa_dblock @ bytes_to_off(hdr.dblk_addr_raw)`.
+    variants:
+      paged:
+        desc: "Paged prefix layout. Active when `global_fa_npages > 0`."
+      nopaged:
+        desc: "Inline element layout. Active when `global_fa_npages == 0`."

--- a/docs/spec/messages.yml
+++ b/docs/spec/messages.yml
@@ -1,0 +1,947 @@
+pickle: messages.pk
+section: "IV.A.2. Disk Format: Level 1A – Object Header Messages"
+intro: |
+  Object header messages carry all the metadata associated with an HDF5
+  object. Each message occupies one slot in an object header chunk and
+  is preceded by a `msg_prefix` (defined in `ohdr.pk`). The message
+  payload begins immediately after the prefix.
+
+  Message type identifiers range from 0x0000 to 0x0018. The
+  `message_factory` function dispatches a raw type ID and file offset to
+  the appropriate typed struct. Unknown types are returned as raw byte
+  arrays and are silently skipped.
+
+  Several messages exist in an "old" and a "new" versioned form:
+  `H5O_msg_old_fill` / `H5O_msg_fill` and `H5O_msg_old_mtime` /
+  `H5O_msg_mtime`. Applications should write only the new form; the old
+  form is retained for reading legacy files.
+
+  All fields are stored in little-endian byte order.
+
+types:
+
+  # ── Datatype helper types (used by H5O_msg_dtype) ─────────────────────────
+
+  dtype_hdr:
+    desc: >-
+      8-byte common header present at the start of every Datatype message
+      and embedded recursively in compound, enumerated, variable-length,
+      and array types. Encodes the datatype class, format version, and
+      class-specific flags.
+    fields:
+      flags:
+        desc: >-
+          Packed 32-bit field. Bits 0–3: datatype class (0 = fixed-point,
+          1 = floating-point, 2 = time, 3 = string, 4 = bitfield,
+          5 = opaque, 6 = compound, 7 = reference, 8 = enumerated,
+          9 = variable-length, 10 = array). Bits 4–7: format version.
+          Bits 8–23: class bit-fields whose meaning depends on the class.
+      elm_size:
+        desc: "Size in bytes of one element of this datatype."
+
+  compound_props1:
+    desc: >-
+      Per-member descriptor for a version 1 compound datatype. Names are
+      padded to 8-byte boundaries and a legacy array-dimension block is
+      stored but is ignored by all current implementations.
+    fields:
+      memb_name:
+        desc: "NUL-terminated member name string."
+      pad:
+        desc: "Zero bytes padding `memb_name` to the next 8-byte boundary."
+      memb_off:
+        desc: "4-byte byte offset of this member within one compound element."
+      ndim:
+        desc: >-
+          Legacy: number of dimensions in the member's array descriptor.
+          Always 0 in files written by the current library.
+      res1:
+        desc: "Reserved. Must be zero (3 bytes)."
+      perm:
+        desc: "Legacy: permutation index for each dimension (4 bytes; ignored)."
+      res2:
+        desc: "Reserved. Must be zero (4 bytes)."
+      dim_sizes:
+        desc: >-
+          Legacy: 4 × 4 array of dimension sizes. Only the first `ndim`
+          entries are meaningful; the rest are zero.
+      memb_hdr:
+        desc: "8-byte `dtype_hdr` describing this member's datatype."
+      memb_props:
+        desc: "Variable-length type-class properties for the member's datatype."
+
+  compound_props2:
+    desc: >-
+      Per-member descriptor for a version 2 compound datatype. Removes
+      the legacy dimension block present in version 1.
+    fields:
+      memb_name:
+        desc: "NUL-terminated member name, padded to 8-byte boundary."
+      pad:
+        desc: "Zero bytes padding `memb_name` to the next 8-byte boundary."
+      memb_off:
+        desc: "4-byte byte offset of this member within one compound element."
+      memb_hdr:
+        desc: "8-byte `dtype_hdr` describing this member's datatype."
+      memb_props:
+        desc: "Variable-length type-class properties for the member's datatype."
+
+  compound_props3:
+    desc: >-
+      Per-member descriptor for a version 3 compound datatype. The member
+      offset field is variable-width (1, 2, 4, or 8 bytes) determined by
+      the total size of the compound element.
+    fields:
+      memb_name:
+        desc: "NUL-terminated member name (no padding)."
+      memb_off:
+        desc: >-
+          Variable-width byte offset of this member. Width is 1 byte if
+          `elm_size < 256`, 2 bytes if `< 65536`, 4 bytes if `< 4 GB`,
+          otherwise 8 bytes.
+      memb_hdr:
+        desc: "8-byte `dtype_hdr` describing this member's datatype."
+      memb_props:
+        desc: "Variable-length type-class properties for the member's datatype."
+
+  enum_props:
+    desc: >-
+      Per-member name entry for version 1 and 2 enumerated datatypes.
+      In version 3 the names are stored as plain NUL-terminated strings
+      without padding.
+    fields:
+      name:
+        desc: "NUL-terminated enumeration member name."
+      pad:
+        desc: "Zero bytes padding the name to the next 8-byte boundary."
+
+  array_props2:
+    desc: >-
+      Array datatype dimension descriptor for version 2. Includes a
+      permutation index array that is always set to identity order
+      `(0, 1, 2, …)` in files written by the current library.
+    fields:
+      ndims:
+        desc: "Number of array dimensions."
+      res:
+        desc: "Reserved. Must be zero (3 bytes)."
+      dim_size:
+        desc: "Array of `ndims` uint32 dimension extents."
+      perm_size:
+        desc: "Array of `ndims` uint32 permutation indices (legacy; always identity)."
+
+  array_props3:
+    desc: "Array datatype dimension descriptor for version 3. The permutation array is removed."
+    fields:
+      ndims:
+        desc: "Number of array dimensions."
+      dim_size:
+        desc: "Array of `ndims` uint32 dimension extents."
+
+  filt_descr:
+    desc: >-
+      Descriptor for one filter in the filter pipeline message. Version 1
+      appends a `padding` field when `cd_nelmts` is odd; version 2 omits
+      the padding.
+    fields:
+      id:
+        desc: >-
+          Filter identification number. Values 1–255 are reserved for
+          filters registered with The HDF Group; values 256–65535 are
+          available for third-party filters. Well-known IDs: 1 = DEFLATE
+          (zlib), 2 = SHUFFLE, 3 = FLETCHER32, 4 = SZIP, 5 = NBIT,
+          6 = SCALEOFFSET.
+      name_len:
+        desc: >-
+          Byte length of the optional `name` array including the NUL
+          terminator. Zero when no name is stored.
+      flags:
+        desc: >-
+          Filter flags. Bit 0: filter is optional — if it cannot be
+          applied the data is stored without filtering.
+      cd_nelmts:
+        desc: "Number of uint32 client-data values in `cd_data`."
+      name:
+        desc: "Optional NUL-terminated filter name. Present only when `name_len > 0`."
+        note: optional
+      cd_data:
+        desc: "Array of `cd_nelmts` uint32 parameters passed to the filter."
+      padding:
+        desc: >-
+          4-byte alignment padding. Present in version 1 only, and only
+          when `cd_nelmts` is odd.
+        note: "version 1 only, when cd_nelmts is odd"
+
+  # ── Message types 0x0000–0x0018 ───────────────────────────────────────────
+
+  H5O_msg_nil:
+    desc: >-
+      Null message (type 0x0000). An empty, zero-length payload used to
+      fill gaps left when a previous message was deleted or when an
+      object header chunk is created with reserved space.
+
+  H5O_msg_sdspace:
+    desc: >-
+      Dataspace message (type 0x0001). Describes the shape and
+      dimensionality of a dataset, including current dimension sizes and,
+      optionally, maximum dimension sizes.
+    fields:
+      version:
+        desc: "Format version. Valid values: 1 and 2."
+    variants:
+      v1:
+        desc: "Version 1 dataspace. Uses a fixed 5-byte reserved block."
+        fields:
+          ndims:
+            desc: "Number of dimensions (0 = scalar)."
+          flags:
+            desc: >-
+              Bit 0: maximum dimension sizes are present (`max` field
+              follows). Bit 1: permutation indices are present (`perm`
+              field follows; never written by the library).
+          res:
+            desc: "Reserved. Must be zero (5 bytes)."
+          dim_size:
+            desc: "Array of `ndims` current dimension sizes, each `sizeof_lengths` bytes."
+          max:
+            desc: >-
+              Array of `ndims` maximum dimension sizes. `0xFFFF…FF`
+              denotes unlimited. Present when `flags` bit 0 is set.
+            note: optional
+          perm:
+            desc: "Permutation indices. Present when `flags` bit 1 is set."
+            note: "optional; never written by the library"
+      v2:
+        desc: "Version 2 dataspace. Replaces the reserved block with an explicit space-type byte."
+        fields:
+          ndims:
+            desc: "Number of dimensions."
+          flags:
+            desc: "Bit 0: maximum dimension sizes are present (`max` field follows)."
+          space_type:
+            desc: "Dataspace class: 0 = H5S_SCALAR, 1 = H5S_SIMPLE, 2 = H5S_NULL."
+          dim_size:
+            desc: "Array of `ndims` current dimension sizes."
+          max:
+            desc: "Array of `ndims` maximum dimension sizes. Present when `flags` bit 0 is set."
+            note: optional
+
+  H5O_msg_linfo:
+    desc: >-
+      Link info message (type 0x0002). Carries addresses of the fractal
+      heap and B-trees used for dense link storage, and optionally the
+      maximum creation order index assigned to a link in this group.
+    fields:
+      version:
+        desc: "Format version. Must be 0."
+      flags:
+        desc: >-
+          Bit 0: creation order is tracked — `max_corder` is present.
+          Bit 1: creation order is indexed — `corder_bt2_addr_raw` is
+          present.
+      max_corder:
+        desc: "Maximum creation order value assigned to a link. Present when `flags` bit 0 is set."
+        note: optional
+      fheap_addr_raw:
+        desc: "File address of the fractal heap for dense link storage. HADDR_UNDEF when compact."
+      name_bt2_addr_raw:
+        desc: "File address of the v2 B-tree indexing link names. HADDR_UNDEF when compact."
+      corder_bt2_addr_raw:
+        desc: >-
+          File address of the v2 B-tree indexing link creation order.
+          Present when `flags` bit 1 is set.
+        note: optional
+
+  H5O_msg_dtype:
+    desc: >-
+      Datatype message (type 0x0003). Fully describes the type of a
+      dataset's elements or an attribute's values. The datatype class
+      is encoded in `hdr.flags` bits 0–3; the format version in bits
+      4–7. Compound, enumerated, variable-length, and array types embed
+      one or more recursive `dtype_hdr` + properties blocks.
+    fields:
+      hdr:
+        desc: "Common 8-byte datatype header (`dtype_hdr`): class, version, class flags, element size."
+    variants:
+      fixed_point:
+        desc: "Class 0. Unsigned or signed integer stored in a fixed number of bits."
+        fields:
+          bit_offset:
+            desc: "Bit offset of the first significant bit within the element."
+          bit_precision:
+            desc: "Number of significant bits."
+      floating_point:
+        desc: >-
+          Class 1. IEEE or VAX floating-point number. The byte order,
+          padding, normalization, and exponent bias are encoded in
+          `hdr.flags` class bits.
+        fields:
+          bit_offset:
+            desc: "Bit offset of the first significant bit."
+          bit_precision:
+            desc: "Total number of bits in the floating-point value."
+          eloc:
+            desc: "Bit position of the least-significant exponent bit."
+          esize:
+            desc: "Number of bits in the exponent."
+          mloc:
+            desc: "Bit position of the least-significant mantissa bit."
+          msize:
+            desc: "Number of bits in the mantissa."
+          ebias:
+            desc: "Exponent bias value."
+      time:
+        desc: >-
+          Class 2. Fixed-precision time value. Byte order is in
+          `hdr.flags` class bits.
+        fields:
+          bit_precision:
+            desc: "Number of bits used to represent the time value."
+      text_string:
+        desc: >-
+          Class 3. Fixed-length character string. Padding type (null-
+          terminate, null-pad, or space-pad) and character set (ASCII
+          or UTF-8) are encoded entirely in `hdr.flags` class bits;
+          there are no additional property bytes on disk.
+      bitfield:
+        desc: "Class 4. Sequence of bits within a larger byte array. Layout mirrors fixed-point."
+        fields:
+          bit_offset:
+            desc: "Bit offset of the first significant bit."
+          bit_precision:
+            desc: "Number of significant bits."
+      opaque:
+        desc: >-
+          Class 5. Uninterpreted raw bytes. The tag length is encoded in
+          `hdr.flags` class bits (bits 8–15).
+        fields:
+          tag:
+            desc: "ASCII tag string describing the opaque data."
+          pad:
+            desc: "Zero bytes padding `tag` to the next 8-byte boundary."
+      compound:
+        desc: >-
+          Class 6. Heterogeneous record type. The number of members is
+          encoded in `hdr.flags` class bits (bits 8–23). Member layout
+          differs between format versions 1, 2, and 3.
+        fields:
+          membs:
+            desc: "Union holding the version-appropriate array of member descriptors."
+        variants:
+          v1:
+            desc: "Version 1 members: array of `compound_props1`, one entry per member."
+          v2:
+            desc: "Version 2 members: array of `compound_props2`, one entry per member."
+          v3:
+            desc: "Version 3 members: array of `compound_props3`, one entry per member."
+      reference:
+        desc: >-
+          Class 7. Reference to another HDF5 object or region. The
+          reference type and, for version 4+, the encoded version are
+          in `hdr.flags` class bits. No additional property bytes.
+      enumeration:
+        desc: >-
+          Class 8. Mapping of integer values to symbolic names. The
+          number of members is in `hdr.flags` class bits (bits 8–23).
+          Embeds a recursive base-type descriptor followed by member
+          names and values.
+        fields:
+          base_hdr:
+            desc: "8-byte `dtype_hdr` of the underlying integer base type."
+          base_props:
+            desc: "Type-class properties for the base type."
+          memb_names:
+            desc: "Union holding member name strings, version-dependent."
+          memb_values:
+            desc: "Packed array of `num_members × base_hdr.elm_size` bytes, one value per member."
+        variants:
+          v1_2:
+            desc: >-
+              Member names for versions 1 and 2: array of `enum_props`,
+              each NUL-terminated and padded to 8 bytes.
+          v3:
+            desc: "Member names for version 3: array of plain NUL-terminated strings."
+      variable_length:
+        desc: >-
+          Class 9. Variable-length sequence or string. The VL type
+          (sequence vs. string) is in `hdr.flags` class bits. Embeds a
+          recursive base-type descriptor.
+        fields:
+          base_hdr:
+            desc: "8-byte `dtype_hdr` of the base element type."
+          base_props:
+            desc: "Type-class properties for the base type."
+      array:
+        desc: >-
+          Class 10. Fixed-size multidimensional array of a base type.
+          Dimension information differs between versions 2 and 3.
+        fields:
+          arr:
+            desc: "Union holding the version-appropriate dimension descriptor."
+          base_hdr:
+            desc: "8-byte `dtype_hdr` of the array element type."
+          base_props:
+            desc: "Type-class properties for the element type."
+        variants:
+          v2:
+            desc: "Version 2 array dimensions: `array_props2` (with permutation array)."
+          v3:
+            desc: "Version 3 array dimensions: `array_props3` (without permutation array)."
+
+  H5O_msg_old_fill:
+    desc: >-
+      Fill value message, old form (type 0x0004). Stores a single raw fill
+      value without versioning or allocation-time metadata. Present only
+      in legacy files; new files use `H5O_msg_fill`.
+    fields:
+      fill_size:
+        desc: "Size in bytes of the fill value. Zero means no fill value is defined."
+      fill_value:
+        desc: "Raw fill value bytes. Present only when `fill_size > 0`."
+        note: optional
+
+  H5O_msg_fill:
+    desc: >-
+      Fill value message, new form (type 0x0005). Extends the old form
+      with explicit allocation- and fill-time controls and a defined/
+      undefined flag.
+    fields:
+      version:
+        desc: "Format version. Valid values: 1, 2, 3."
+    variants:
+      v1_v2:
+        desc: "Versions 1 and 2: explicit allocation-time, fill-time, and defined flag."
+        fields:
+          alloc_time:
+            desc: >-
+              When storage space is allocated: 0 = early (on creation),
+              1 = late (on first write), 2 = incremental.
+          fill_time:
+            desc: >-
+              When fill values are written: 0 = on allocation,
+              1 = never, 2 = if user-defined fill value is set.
+          fill_defined:
+            desc: "Non-zero if a user-defined fill value is stored."
+          fill_size:
+            desc: "Byte size of the fill value. Present only when `fill_defined > 0`."
+            note: optional
+          fill_value:
+            desc: "Raw fill value bytes. Present when `fill_defined > 0` and `fill_size > 0`."
+            note: optional
+      v3:
+        desc: >-
+          Version 3: allocation-time and fill-time are packed into a
+          single flags byte; the fill-defined bit eliminates the
+          separate `fill_defined` field.
+        fields:
+          flags:
+            desc: >-
+              Bits 0–1: allocation time (same values as v1/v2
+              `alloc_time`). Bits 2–3: fill time (same values as v1/v2
+              `fill_time`). Bit 5: fill value is defined (replaces the
+              separate `fill_defined` field).
+          fill_size:
+            desc: "Byte size of the fill value. Present when `flags` bit 5 is set."
+            note: optional
+          fill_value:
+            desc: "Raw fill value bytes. Present when `flags` bit 5 is set and `fill_size > 0`."
+            note: optional
+
+  H5O_msg_link:
+    desc: >-
+      Link message (type 0x0006). Describes one link within a group. The
+      link type (hard, soft, external, or user-defined) is encoded in the
+      `flags` field.
+    fields:
+      version:
+        desc: "Format version. Must be 1."
+      flags:
+        desc: >-
+          Bits 0–1: byte width of the `lnk_len` field (00 = 1 byte,
+          01 = 2 bytes, 10 = 4 bytes, 11 = 8 bytes). Bit 2: creation
+          order is stored (`corder` field present). Bit 3: link type is
+          explicitly stored (`lnk_type` field present). Bit 4: character
+          set is stored (`cset` field present).
+      lnk_type:
+        desc: >-
+          Link type byte. 0 = hard link, 1 = soft link, 64 = external
+          link, 255 = user-defined link. Present only when `flags`
+          bit 3 is set (otherwise the type is hard, i.e. 0).
+        note: optional
+      corder:
+        desc: "Link creation order value. Present only when `flags` bit 2 is set."
+        note: optional
+      cset:
+        desc: "Character set of the link name: 0 = ASCII, 1 = UTF-8. Present when `flags` bit 4 is set."
+        note: optional
+      lnk_len:
+        desc: "Byte length of the link name array `lnk_name`. Width determined by `flags` bits 0–1."
+      lnk_name:
+        desc: "Link name character array (not NUL-terminated)."
+      ohdr_addr_raw:
+        desc: "Target object header address. Present only for hard links (`lnk_type == 0`)."
+        note: "hard links only"
+      soft_len:
+        desc: "Byte length of the soft-link target string. Present only for soft links."
+        note: "soft links only"
+      soft_name:
+        desc: "Soft-link target path (not NUL-terminated). Present when `soft_len > 0`."
+        note: "soft links only"
+      ud_len:
+        desc: "Byte length of the user-defined link data. Present for external and user-defined links."
+        note: "external/user-defined links only"
+      ud_data:
+        desc: >-
+          User-defined link data. For external links this is a
+          NUL-terminated file path followed by a NUL-terminated object
+          path. Present when `ud_len > 0`.
+        note: "external/user-defined links only"
+
+  H5O_msg_layout:
+    desc: >-
+      Data layout message (type 0x0008). Specifies how a dataset's raw
+      data are stored on disk: compact (inside the object header),
+      contiguous, chunked, or virtual. Four format versions are defined;
+      versions 1 and 2 share the same struct.
+    fields:
+      version:
+        desc: "Format version. Valid values: 1, 2, 3, 4."
+    variants:
+      v1_v2:
+        desc: "Layout for versions 1 and 2. The layout class is a separate field from the dimensionality."
+        fields:
+          ndims:
+            desc: "Number of dimensions plus one (the extra entry holds the element size)."
+          layout_class:
+            desc: "Storage class: 0 = compact, 1 = contiguous, 2 = chunked."
+          res:
+            desc: "Reserved. Must be zero (5 bytes)."
+        variants:
+          contig:
+            desc: "Contiguous layout properties (layout_class == 1)."
+            fields:
+              data_addr_raw:
+                desc: "File address of the contiguous data block."
+              dim_size:
+                desc: "Array of `ndims` uint32 dimension sizes."
+          chunked:
+            desc: "Chunked layout properties (layout_class == 2)."
+            fields:
+              idx_addr_raw:
+                desc: "File address of the v1 B-tree chunk index."
+              dim_size:
+                desc: "Array of `ndims` uint32 dimension sizes (last entry = element size)."
+          compact:
+            desc: "Compact layout properties (layout_class == 0)."
+            fields:
+              dim_size:
+                desc: "Array of `ndims` uint32 dimension sizes."
+              size:
+                desc: "Number of bytes of raw data stored inline."
+              compact_data:
+                desc: "Inline raw data bytes. Present only when `size > 0`."
+                note: optional
+      v3:
+        desc: "Layout version 3. Layout class moves to the front; dimensionality is per-class."
+        fields:
+          layout_class:
+            desc: "Storage class: 0 = compact, 1 = contiguous, 2 = chunked."
+        variants:
+          compact:
+            desc: "Compact storage (layout_class == 0)."
+            fields:
+              size:
+                desc: "Number of bytes of raw data stored inline."
+              raw_data:
+                desc: "Inline raw data bytes. Present only when `size > 0`."
+                note: optional
+          contig:
+            desc: "Contiguous storage (layout_class == 1)."
+            fields:
+              data_addr_raw:
+                desc: "File address of the contiguous data block."
+              data_size_raw:
+                desc: "Size in bytes of the contiguous data block."
+          chunked:
+            desc: "Chunked storage (layout_class == 2)."
+            fields:
+              ndims:
+                desc: "Number of chunk dimensions."
+              idx_addr_raw:
+                desc: "File address of the v1 B-tree chunk index."
+              dim_size:
+                desc: "Array of `ndims` uint32 chunk dimension sizes."
+      v4:
+        desc: >-
+          Layout version 4. Chunked storage gains an explicit index type
+          field with per-type parameters; virtual storage is added.
+        fields:
+          layout_class:
+            desc: "Storage class: 0 = compact, 1 = contiguous, 2 = chunked, 3 = virtual."
+        variants:
+          compact:
+            desc: "Compact storage (layout_class == 0)."
+            fields:
+              size:
+                desc: "Number of bytes of raw data stored inline."
+              raw_data:
+                desc: "Inline raw data bytes. Present only when `size > 0`."
+                note: optional
+          contig:
+            desc: "Contiguous storage (layout_class == 1)."
+            fields:
+              data_addr_raw:
+                desc: "File address of the contiguous data block."
+              data_size_raw:
+                desc: "Size in bytes of the contiguous data block."
+          chunked:
+            desc: "Chunked storage (layout_class == 2)."
+            fields:
+              flags:
+                desc: >-
+                  Bit 0: chunk dimension sizes use a filter. Bit 1: a
+                  single-chunk index with filters is used (filter
+                  metadata present in the index parameters).
+              ndims:
+                desc: "Number of chunk dimensions."
+              enc_bytes_per_dim:
+                desc: "Number of bytes used to encode each entry of `dim_size`."
+              dim_size:
+                desc: "Array of `ndims` chunk dimension sizes, each `enc_bytes_per_dim` bytes."
+              idx_type:
+                desc: >-
+                  Chunk index type: 1 = single-chunk, 2 = implicit
+                  (compact/contiguous), 3 = fixed array, 4 = extensible
+                  array, 5 = version 2 B-tree.
+              idx_addr_raw:
+                desc: "File address of the chunk index data structure."
+            variants:
+              single:
+                desc: "Single-chunk index parameters (idx_type == 1)."
+                fields:
+                  filter_chunk_size:
+                    desc: >-
+                      Filtered chunk size in bytes (`sizeof_lengths`
+                      bytes). Present only when `flags` bit 1 is set.
+                    note: optional
+                  filter_mask:
+                    desc: >-
+                      Filter pipeline skip mask for the single chunk.
+                      Present only when `flags` bit 1 is set.
+                    note: optional
+              implicit:
+                desc: "Implicit index (idx_type == 2). No additional parameters stored."
+              farray:
+                desc: "Fixed Array index parameters (idx_type == 3)."
+                fields:
+                  max_dblk_page_nelmts_bits:
+                    desc: >-
+                      Log2 of the maximum number of elements in a data
+                      block page.
+              earray:
+                desc: "Extensible Array index parameters (idx_type == 4)."
+                fields:
+                  max_nelmts_bits:
+                    desc: "Log2 of the maximum number of elements in the array."
+                  idx_blk_elmts:
+                    desc: "Number of elements to store in the index block."
+                  sup_blk_min_data_ptrs:
+                    desc: "Minimum number of data block pointers in a super block."
+                  data_blk_min_elmts:
+                    desc: "Minimum number of elements per data block."
+                  max_dblk_page_nelmts_bits:
+                    desc: >-
+                      Log2 of the maximum number of elements in a data
+                      block page.
+                    note: "1 byte in the pickle; the spec specifies 2 bytes"
+              bt2:
+                desc: "Version 2 B-tree index parameters (idx_type == 5)."
+                fields:
+                  node_size:
+                    desc: "Size of each B-tree node in bytes."
+                  split_percent:
+                    desc: "Node occupancy (%) above which the node is split."
+                  merge_percent:
+                    desc: "Node occupancy (%) below which two nodes are merged."
+          virtual:
+            desc: "Virtual storage (layout_class == 3)."
+            fields:
+              gheap_addr_raw:
+                desc: "File address of the global heap collection holding the VDS mapping."
+              idx:
+                desc: "Index of the VDS entry within the global heap collection."
+
+  H5O_msg_ginfo:
+    desc: >-
+      Group info message (type 0x000a). Stores optional parameters
+      controlling when a group switches between compact and dense link
+      storage, and estimated size hints for newly created groups.
+    fields:
+      version:
+        desc: "Format version. Must be 0."
+      flags:
+        desc: >-
+          Bit 0: compact/dense phase-change thresholds are stored
+          (`max_compact` and `min_dense` present). Bit 1: group size
+          estimates are stored (`est_num_entries` and `est_name_len`
+          present).
+      max_compact:
+        desc: "Maximum number of links in compact form before conversion to indexed. Present when `flags` bit 0 is set."
+        note: optional
+      min_dense:
+        desc: "Minimum number of links in indexed form before conversion to compact. Present when `flags` bit 0 is set."
+        note: optional
+      est_num_entries:
+        desc: "Estimated number of entries in new groups. Present when `flags` bit 1 is set."
+        note: optional
+      est_name_len:
+        desc: "Estimated average length of link names. Present when `flags` bit 1 is set."
+        note: optional
+
+  H5O_msg_pline:
+    desc: >-
+      Filter pipeline message (type 0x000b). Lists the filters that are
+      applied to a dataset's raw data in order. Versions 1 and 2 differ
+      only in the filter descriptor layout.
+    fields:
+      version:
+        desc: "Format version. Valid values: 1, 2."
+      nfilters:
+        desc: "Number of filter descriptors in the pipeline (0–32)."
+    variants:
+      v1:
+        desc: "Version 1 pipeline. The filter list is preceded by a 6-byte reserved block."
+        fields:
+          res:
+            desc: "Reserved. Must be zero (6 bytes)."
+          filt_list:
+            desc: "Array of `nfilters` version 1 `filt_descr` entries."
+      v2:
+        desc: "Version 2 pipeline. The reserved block is removed; the filter list begins immediately."
+        fields:
+          filt_list:
+            desc: "Array of `nfilters` version 2 `filt_descr` entries."
+
+  H5O_msg_attr:
+    desc: >-
+      Attribute message (type 0x000c). Stores an attribute inline in the
+      object header. Each attribute consists of a name, a datatype, a
+      dataspace, and a data payload; versions 1 and 3 align the name,
+      datatype, and dataspace to 8 bytes, while version 2 does not.
+    fields:
+      version:
+        desc: "Format version. Valid values: 1, 2, 3."
+      flags:
+        desc: >-
+          Reserved in version 1 (must be zero). In versions 2 and 3:
+          bit 0 = datatype is shared, bit 1 = dataspace is shared.
+      name_size:
+        desc: "Byte length of the `name` field (including NUL terminator in v1)."
+      dtype_size:
+        desc: "Byte length of the `dtype` field."
+      dspace_size:
+        desc: "Byte length of the `dspace` field."
+      cset:
+        desc: "Character set of the attribute name: 0 = ASCII, 1 = UTF-8. Version 3 only."
+        note: "version 3 only"
+      name:
+        desc: >-
+          Attribute name bytes. In version 1 the length is rounded up to
+          an 8-byte boundary; in versions 2 and 3 it is stored exactly.
+      dtype:
+        desc: "Raw datatype message bytes (parsed as `H5O_msg_dtype`)."
+      dspace:
+        desc: "Raw dataspace message bytes (parsed as `H5O_msg_sdspace`)."
+      data:
+        desc: "Raw attribute data bytes (size = `dtype.elm_size × product(dim_sizes)`)."
+
+  H5O_msg_name:
+    desc: >-
+      Object comment message (type 0x000d). Stores a short human-readable
+      comment string for the object. There is no version or length field;
+      the string is NUL-terminated and the message payload size determines
+      its extent.
+    fields:
+      name:
+        desc: "NUL-terminated comment string."
+
+  H5O_msg_old_mtime:
+    desc: >-
+      Modification time message, old form (type 0x000e). Stores an object
+      modification time as broken-out calendar fields rather than a UNIX
+      timestamp. Present only in legacy files; new files use
+      `H5O_msg_mtime`.
+    fields:
+      year:
+        desc: "Calendar year as a signed 32-bit integer."
+      month:
+        desc: "Month of the year (1–12)."
+      mday:
+        desc: "Day of the month (1–31)."
+      hour:
+        desc: "Hour of the day (0–23)."
+      minute:
+        desc: "Minute of the hour (0–59)."
+      second:
+        desc: "Second of the minute (0–60, allowing for a leap second)."
+      res:
+        desc: "Reserved. Must be zero (2 bytes)."
+
+  H5O_msg_shmesg_table:
+    desc: >-
+      Shared object header message table message (type 0x000f). Points to
+      the file-level shared message (SOHM) master table and records the
+      number of indexes it contains.
+    fields:
+      version:
+        desc: "Format version. Must be 0."
+      addr_raw:
+        desc: "File address of the shared object header message master table."
+      nindexes:
+        desc: "Number of shared message indexes in the master table."
+
+  H5O_msg_cont:
+    desc: >-
+      Object header continuation message (type 0x0010). Points to an
+      additional object header chunk on disk, allowing an object header to
+      span multiple non-contiguous blocks.
+    fields:
+      addr_raw:
+        desc: "File address of the continuation block."
+      size_raw:
+        desc: "Byte size of the continuation block."
+
+  H5O_msg_stab:
+    desc: >-
+      Symbol table message (type 0x0011). Present on groups encoded with
+      the version 1 (legacy) symbol table structure. Points to the group's
+      v1 B-tree and local heap.
+    fields:
+      btree_addr_raw:
+        desc: "File address of the root node of the version 1 group B-tree."
+      heap_addr_raw:
+        desc: "File address of the local heap containing link name strings."
+
+  H5O_msg_mtime:
+    desc: >-
+      Modification time message, new form (type 0x0012). Stores the
+      object modification time as a UNIX timestamp.
+    fields:
+      version:
+        desc: "Format version. Must be 1."
+      res:
+        desc: "Reserved. Must be zero (3 bytes)."
+      seconds:
+        desc: "UNIX timestamp (seconds since 1970-01-01 00:00:00 UTC) of the last metadata modification."
+
+  H5O_msg_btreek:
+    desc: >-
+      Version 1 B-tree K values message (type 0x0013). Overrides the
+      file-global B-tree K values from the superblock for this particular
+      object. Stored in the superblock extension object header.
+    fields:
+      version:
+        desc: "Format version. Must be 0."
+      btree_k_chunk:
+        desc: "Internal node K value for the indexed (chunked) storage v1 B-tree."
+      btree_k_snode:
+        desc: "Internal node K value for the group (symbol table) v1 B-tree."
+      sym_leaf_k:
+        desc: "Leaf node K value for the group (symbol table) v1 B-tree."
+
+  H5O_msg_drvinfo:
+    desc: >-
+      Driver information message (type 0x0014). Stores a driver-specific
+      opaque information block identified by an 8-byte ASCII name.
+      Written only by drivers that need to persist private metadata
+      (e.g. multi or family virtual file drivers).
+    fields:
+      version:
+        desc: "Format version. Must be 0."
+      name:
+        desc: "8-byte ASCII driver name (not NUL-terminated). Identifies the driver and the format of `info_buf`."
+      info_len:
+        desc: "Byte size of `info_buf`."
+      info_buf:
+        desc: "Driver-specific information bytes of length `info_len`."
+
+  H5O_msg_ainfo:
+    desc: >-
+      Attribute info message (type 0x0015). Stores addresses of the
+      fractal heap and B-trees used for dense attribute storage, mirrors
+      `H5O_msg_linfo` but for attributes rather than links.
+    fields:
+      version:
+        desc: "Format version. Must be 0."
+      flags:
+        desc: >-
+          Bit 0: creation order is tracked — `max_crt_idx` is present.
+          Bit 1: creation order is indexed — `corder_bt2_addr_raw` is
+          present.
+      max_crt_idx:
+        desc: "Maximum creation order value assigned to an attribute. Present when `flags` bit 0 is set."
+        note: optional
+      fheap_addr_raw:
+        desc: "File address of the fractal heap for dense attribute storage. HADDR_UNDEF when compact."
+      name_bt2_addr_raw:
+        desc: "File address of the v2 B-tree indexing attribute names."
+      corder_bt2_addr_raw:
+        desc: "File address of the v2 B-tree indexing attribute creation order. Present when `flags` bit 1 is set."
+        note: optional
+
+  H5O_msg_refcount:
+    desc: >-
+      Object reference count message (type 0x0016). Stores the count of
+      hard links pointing to the object when that count exceeds what fits
+      in the version 1 object header's 32-bit field.
+    fields:
+      version:
+        desc: "Format version. Must be 0."
+      ref_cnt:
+        desc: "Current hard-link reference count."
+
+  H5O_msg_fsinfo:
+    desc: >-
+      File space info message (type 0x0017). Describes the file space
+      management strategy and stores addresses of the free-space managers
+      for small and large allocations. Stored in the superblock extension.
+    fields:
+      version:
+        desc: "Format version. Values 0 and 1 use identical layouts."
+      strategy:
+        desc: >-
+          File space management strategy: 1 = FSM_AGGR (free-space
+          manager with aggregation), 2 = PAGE (paged allocation),
+          3 = AGGR (aggregation only), 4 = NONE (no tracking).
+      persist:
+        desc: "Non-zero if the free-space manager state is persisted across file opens."
+      threshold:
+        desc: "Minimum free-space section size (`sizeof_lengths` bytes) that is tracked."
+      page_size:
+        desc: "File space page size (`sizeof_lengths` bytes)."
+        note: "field position differs from the specification"
+      pgend_meta_thres:
+        desc: "Threshold for storing small metadata at the end of a page."
+      eoa:
+        desc: "Stored end-of-address value (`sizeof_offsets` bytes)."
+      small_fs_addr:
+        desc: >-
+          Array of 6 file addresses (`sizeof_offsets` bytes each) for the
+          small-allocation free-space managers, one per allocation type.
+      large_fs_addr:
+        desc: >-
+          Array of 6 file addresses for the large-allocation free-space
+          managers, one per allocation type.
+
+  H5O_msg_mdci:
+    desc: >-
+      Metadata cache image message (type 0x0018). Points to a serialized
+      snapshot of the metadata cache written at file close to accelerate
+      the next file open. Not described in the public format specification.
+    fields:
+      version:
+        desc: "Format version. Must be 0."
+      image_addr_raw:
+        desc: "File address of the serialized metadata cache image block."
+      image_size:
+        desc: "Byte size of the metadata cache image block (`sizeof_lengths` bytes)."

--- a/docs/spec/ohdr.yml
+++ b/docs/spec/ohdr.yml
@@ -1,0 +1,205 @@
+pickle: ohdr.pk
+section: "IV.A.2. Disk Format: Level 1A – Object Headers"
+skip_types:
+  - cont_chunk   # poke runtime helper: dynamically-sized byte buffer, not an on-disk type
+intro: |
+  Object headers store all metadata associated with an HDF5 data object
+  (a group or a dataset). Every object header is composed of a prefix
+  followed by a sequence of variable-length messages; the messages
+  describe the object's dataspace, datatype, storage layout, attributes,
+  and other properties.
+
+  Two object header versions are defined. Version 1 is the original
+  format. Version 2 is more compact: it narrows several fields, makes
+  timestamps and attribute phase-change thresholds optional, and adds a
+  checksum over the entire header.
+
+  An object header may span more than one contiguous block on disk.
+  Additional blocks are called continuation chunks and are referenced by
+  Object Header Continuation messages (type 0x0010) within the preceding
+  chunk. Each version 2 continuation chunk is delimited by the 4-byte
+  signature 'O' 'C' 'H' 'K' and ends with a 4-byte checksum.
+
+  All object header fields are stored in little-endian byte order.
+
+types:
+  Timestamps:
+    desc: >
+      Four UNIX timestamps optionally embedded in a version 2 object
+      header. Present when bit 5 of the object header `flags` field is
+      set. Each value is a 32-bit unsigned seconds count relative to the
+      UNIX epoch (1970-01-01 00:00:00 UTC).
+    fields:
+      access:
+        desc: "Time of the last read access to the object."
+      modification:
+        desc: "Time of the last write to the object's raw data."
+      change:
+        desc: "Time of the last change to the object's metadata."
+      birth:
+        desc: "Time at which the object was created."
+
+  AttrPhase:
+    desc: >
+      Attribute storage phase-change thresholds optionally embedded in a
+      version 2 object header. Present when bit 4 of `flags` is set.
+      These thresholds control when the HDF5 library switches between
+      compact attribute storage (inside the object header) and indexed
+      attribute storage (in a fractal heap and B-tree).
+    fields:
+      max_compact:
+        desc: >
+          Maximum number of attributes stored in compact form before the
+          library converts to indexed storage. Once the count exceeds this
+          value the library migrates to a fractal heap and B-tree.
+      min_dense:
+        desc: >
+          Minimum number of attributes that must remain in indexed storage
+          before the library converts back to compact form. Must be less
+          than or equal to `max_compact`.
+
+  msg_prefix:
+    desc: >
+      Fixed-size header that precedes every message payload in an object
+      header chunk. The layout differs between version 1 and version 2
+      headers; the active arm is selected by the global version state set
+      when the enclosing `ohdr` is mapped.
+    variants:
+      v1_msg_prefix:
+        desc: >
+          Version 1 message prefix (5 bytes of declared fields; the
+          `Get_messages` logic accounts for 3 additional reserved bytes
+          beyond this struct, giving an effective prefix size of 8 bytes).
+        fields:
+          msg_type:
+            desc: >
+              16-bit message type identifier. Values 0x0000–0x001F are
+              defined by the HDF5 specification; all others are reserved.
+          msg_size:
+            desc: >
+              Size of the message payload in bytes, not including this
+              prefix or the 3 reserved bytes that follow it.
+          msg_flags:
+            desc: >
+              Bit flags applying to this message.
+              Bit 0: message data is constant after object creation and
+              may be cached or shared.
+              Bit 1: message is shared (payload is a Shared Message record
+              rather than the message data itself).
+              Bit 2: this message must not be shared.
+              Bit 3: the HDF5 library may skip this message on open if it
+              does not understand it.
+              Bit 4: this message was marked as shareable but has not yet
+              been moved to the shared message table.
+              Bit 5: the object header was created before version 1.6 and
+              this message was not originally encoded as a shared message.
+      v2_msg_prefix:
+        desc: >
+          Version 2 message prefix (4 bytes without creation-order
+          tracking, 6 bytes with it). The type field narrows from 16 to
+          8 bits compared with the version 1 prefix.
+        fields:
+          msg_type:
+            desc: "8-bit message type identifier."
+          msg_size:
+            desc: "Size of the message payload in bytes, not including this prefix."
+          msg_flags:
+            desc: "Bit flags (same bit definitions as in `v1_msg_prefix`)."
+          crt_order:
+            desc: >
+              Creation order index of this message within the object
+              header. Present only when bit 2 of the enclosing object
+              header's `flags` field is set.
+            note: optional
+
+  ohdr:
+    desc: >
+      An HDF5 object header in either version 1 or version 2 format.
+      The first four bytes are mapped twice: once as `sig_peek` (pinned
+      at offset 0 without consuming bytes) to select the correct union
+      arm, and again as part of the chosen version struct.
+    fields:
+      sig_peek:
+        desc: >
+          Four bytes read at file offset 0 of the header without
+          advancing the read position. If equal to the signature
+          'O' 'H' 'D' 'R' the version 2 arm is selected; otherwise the
+          version 1 arm is selected.
+    variants:
+      v2:
+        desc: >
+          Version 2 object header layout (identified by the 4-byte
+          signature 'O' 'H' 'D' 'R'). More compact than version 1;
+          adds a checksum and optional timestamps.
+        fields:
+          signature:
+            desc: "4-byte signature: 'O' 'H' 'D' 'R'. Must match the constant V2_SIG."
+          version:
+            desc: "Object header version number. Must be 2."
+          flags:
+            desc: >
+              Bit flags controlling optional fields and the encoding of
+              `chunk0_size`.
+              Bits 0–1: byte width of `chunk0_size`: 00 = 1 byte,
+              01 = 2 bytes, 10 = 4 bytes, 11 = 8 bytes.
+              Bit 2: creation-order tracking is active — message prefixes
+              include the optional `crt_order` field.
+              Bit 3: a creation-order index (B-tree) is maintained for
+              the attributes of this object.
+              Bit 4: the `attr_phase` field is present.
+              Bit 5: the `timestamps` field is present.
+          timestamps:
+            desc: >
+              Optional creation and access timestamps (type `Timestamps`).
+              Present when `flags` bit 5 is set.
+            note: optional
+          attr_phase:
+            desc: >
+              Optional attribute phase-change thresholds (type
+              `AttrPhase`). Present when `flags` bit 4 is set.
+            note: optional
+          chunk0_size:
+            desc: >
+              Size in bytes of the message data in the first object header
+              chunk. Encoded as 1, 2, 4, or 8 bytes according to `flags`
+              bits 0–1. The message data immediately follows this field
+              and is not itself part of the on-disk `ohdr` struct; it is
+              accessed via the internal `_msg_chunk` wrapper.
+          gap:
+            desc: >
+              Zero or more padding bytes between the last message and the
+              checksum in the first chunk. Present only when the messages
+              do not fill the chunk exactly (i.e. when `chunk0_size` is
+              not divisible by the message prefix size).
+            note: optional
+          chksum:
+            desc: >
+              4-byte Jenkins lookup3 checksum computed over all bytes of
+              the object header from `signature` through the last byte of
+              `gap` (or of the final message if there is no gap).
+      v1:
+        desc: >
+          Version 1 object header layout. Identified by a version byte of
+          1 at the start of the header (no signature bytes precede it).
+        fields:
+          version:
+            desc: "Object header version number. Must be 1."
+          res1:
+            desc: "Reserved. Must be zero."
+          msg_cnt:
+            desc: >
+              Total number of header messages across all chunks of this
+              object header, including any continuation chunks.
+          obj_ref_cnt:
+            desc: >
+              Reference count: the number of hard links pointing to this
+              object. An object is eligible for deletion when this count
+              reaches zero.
+          obj_hdr_size:
+            desc: >
+              Size in bytes of the message data in the first object header
+              chunk. The message bytes immediately follow the 16-byte
+              fixed prefix and are accessed via the internal `_msg_chunk`
+              wrapper.
+          res2:
+            desc: "Reserved. Must be zero (4 bytes)."

--- a/docs/spec/superblock.yml
+++ b/docs/spec/superblock.yml
@@ -1,0 +1,179 @@
+pickle: superblock.pk
+section: "IV.A.1. Disk Format: Level 0A – File Signatures and Superblock"
+intro: |
+  The superblock contains the information needed to access all other
+  HDF5 data structures. It must begin at address 0 within the HDF5 file,
+  or at one of the following powers-of-two offsets: 512, 1024, 2048, …
+  bytes from the beginning of the file. Libraries that do not write the
+  superblock at offset zero must scan those candidate offsets for the
+  8-byte signature to locate it.
+
+  Four superblock versions are defined. Versions 0 and 1 share the same
+  basic layout but version 1 adds a field for the indexed-storage
+  internal-node K value. Versions 2 and 3 use a more compact layout that
+  replaces the symbol-table root group entry with a plain object header
+  address and adds a checksum. Version 3 additionally restricts which
+  bits of the consistency flags field may be set.
+
+types:
+  stab_ent:
+    desc: >
+      Symbol table entry for the root group object, embedded directly in
+      superblock versions 0 and 1. Each entry records the object header
+      address, a cache type, and a scratch-pad area whose meaning depends
+      on the cache type.
+    fields:
+      lnk_nm_off_raw:
+        desc: >
+          Byte offset of the link name within the root local heap's
+          data segment. For the root entry this field is not meaningful
+          and is typically zero.
+      ohdr_addr_raw:
+        desc: "File address of the object header for the root group."
+      cache_type:
+        desc: >
+          Indicates what is cached in the scratch-pad space.
+          0 = no cache; 1 = group (B-tree address and heap address are
+          cached); 2 = symbolic link (soft-link target offset is cached).
+          Values 3 and above are reserved.
+      res:
+        desc: "Reserved. Must be zero."
+      scratch_pad:
+        desc: >
+          16-byte scratch-pad area. Interpretation is determined by
+          `cache_type`. See variants below.
+    variants:
+      obj_info:
+        desc: >
+          Present when `cache_type == 1`. Caches the group's B-tree and
+          local heap addresses so that the symbol table can be traversed
+          without first mapping the object header.
+        fields:
+          btree_addr_raw:
+            desc: "File address of the root B-tree node for the group's symbol table."
+          heap_addr_raw:
+            desc: "File address of the local heap containing link names for the group."
+      slink:
+        desc: >
+          Present when `cache_type == 2`. Stores the byte offset of the
+          symbolic-link target string within the local heap.
+      pad:
+        desc: >
+          Present when `cache_type == 0`. The 16 bytes are undefined and
+          should be ignored.
+
+  superblock:
+    desc: "The root on-disk metadata structure of every HDF5 file."
+    fields:
+      signature:
+        desc: >
+          8-byte magic number: `0x89 'H' 'D' 'F' 0x0D 0x0A 0x1A 0x0A`.
+          The leading `0x89` sets the high bit so that systems expecting
+          plain ASCII will reject the file; the CR+LF pair detects
+          newline translation; the `0x1A` stops output on MS-DOS `type`;
+          and the final `0x0A` detects trailing newline suppression.
+      super_vers:
+        desc: >
+          Superblock format version. Valid values: 0, 1, 2, 3. Versions 0
+          and 1 use the `v0_v1` layout; versions 2 and 3 use `v2_v3`.
+    variants:
+      v0_v1:
+        desc: >
+          Layout for superblock versions 0 and 1. Version 1 extends
+          version 0 by adding the `indexed_internal_k` and `res3` fields.
+        fields:
+          fs_info_vers:
+            desc: "Version of the file free-space storage format. Must be 0."
+          root_stab_vers:
+            desc: "Version of the root group symbol table entry format. Must be 0."
+          res1:
+            desc: "Reserved. Must be zero."
+          shared_hdr_vers:
+            desc: "Version of the shared object header message format. Must be 0."
+          sizeof_offsets:
+            desc: >
+              Size in bytes of file addresses (offsets). Typical value: 8.
+              Sets the global `sizeof_offsets` used by all subsequent
+              address fields.
+          sizeof_lengths:
+            desc: >
+              Size in bytes of file lengths. Typical value: 8. Sets the
+              global `sizeof_lengths` used by all length fields.
+          res2:
+            desc: "Reserved. Must be zero."
+          stab_leaf_k:
+            desc: >
+              Half the rank of leaf nodes in the version 1 group B-tree.
+              Must be greater than zero.  The maximum number of entries in
+              a leaf node is `2 * stab_leaf_k`.
+          stab_internal_k:
+            desc: >
+              Half the rank of internal nodes in the version 1 group
+              B-tree. Must be greater than zero.
+          status_flags:
+            desc: >
+              File consistency flags. Bit 0: file is open for write
+              access and may be inconsistent. Bit 1: file has been
+              verified as consistently closed.
+          indexed_internal_k:
+            desc: >
+              Half the rank of internal nodes in the version 1 B-tree used
+              for indexed (chunked) storage. Present only in superblock
+              version 1; must be greater than zero.
+          res3:
+            desc: >
+              Reserved. Must be zero. Present only in superblock version 1,
+              immediately following `indexed_internal_k`.
+          base_addr_raw:
+            desc: >
+              Absolute byte offset of the start of the HDF5 address space
+              within the physical file. Usually 0. All stored addresses
+              are relative to this base.
+          fs_info_addr_raw:
+            desc: >
+              File address of the free-space manager information block, or
+              HADDR_UNDEF (`0xFF…FF`) if free space is not tracked.
+          eof_addr_raw:
+            desc: >
+              File address of the first byte beyond all HDF5 data (the
+              logical end-of-file).
+          drv_info_addr_raw:
+            desc: >
+              File address of the driver information block, or HADDR_UNDEF
+              if no driver information is present.
+          root_stab_ent:
+            desc: "Symbol table entry for the root group (type `stab_ent`)."
+      v2_v3:
+        desc: >
+          Compact layout introduced in superblock version 2. Replaces the
+          symbol-table root entry with a direct object header address and
+          adds a checksum over all preceding superblock bytes. Version 3
+          restricts the consistency flags to bits 0–2 only.
+        fields:
+          sizeof_offsets:
+            desc: >
+              Size in bytes of file addresses. Typical value: 8. Sets the
+              global `sizeof_offsets`.
+          sizeof_lengths:
+            desc: >
+              Size in bytes of file lengths. Typical value: 8. Sets the
+              global `sizeof_lengths`.
+          status_flags:
+            desc: >
+              File consistency flags. In version 2, any bit may be set.
+              In version 3, only bits 0–2 are defined; bits 3–7 must be zero.
+          base_addr_raw:
+            desc: "Absolute byte offset of the start of the HDF5 address space."
+          ext_addr_raw:
+            desc: >
+              File address of the superblock extension object header, or
+              HADDR_UNDEF if no extension is present. The extension carries
+              optional metadata such as the driver information message.
+          eof_addr_raw:
+            desc: "File address of the first byte beyond all HDF5 data."
+          root_obj_addr_raw:
+            desc: "File address of the root group object header."
+          chksum:
+            desc: >
+              Jenkins lookup3 checksum computed over all preceding superblock
+              bytes (from the signature through `root_obj_addr_raw`).

--- a/docs/spec/v1_btree.yml
+++ b/docs/spec/v1_btree.yml
@@ -1,0 +1,152 @@
+pickle: v1_btree.pk
+section: "III.A.1. Disk Format: Level 1A1 – Version 1 B-tree Nodes and Symbol Table Nodes"
+intro: |
+  Version 1 B-trees (on-disk signature 'TREE') are the original indexing
+  structure in HDF5. Two node types are defined:
+
+  - **Node type 0** — group (symbol table) B-tree. Used to index the
+    members of a group stored in the legacy symbol-table format. Leaf
+    children are Symbol Table Nodes (signature 'SNOD').
+  - **Node type 1** — raw-data chunk B-tree. Used to index the chunks
+    of a chunked dataset. At level 0 each child pointer addresses a
+    chunk payload directly.
+
+  The on-disk key/child layout for a node with `entries_used = n` is:
+
+  ```
+  K_0  C_0  K_1  C_1  ...  K_{n-1}  C_{n-1}  K_n
+  ```
+
+  Each node is sized to hold up to `2K` entries (where K is the relevant
+  B-tree K value from the superblock). Only the first `entries_used` pairs
+  are valid; unused capacity beyond that is not mapped by these pickles.
+
+  Before mapping a type-1 node, call `set_bt1_ndims(n)` where n is the
+  dataset dimensionality plus one. Use `print_v1_btree(addr#B, 0)` to
+  recursively print the full tree.
+
+types:
+  bt1_key0:
+    desc: >-
+      Key for a type-0 (group symbol table) B-tree node. Bounds a range
+      of link names by their offset in the group's local heap.
+    fields:
+      name_off_raw:
+        desc: >-
+          Byte offset into the local heap of the first link name in the
+          range covered by this key (`sizeof_lengths` bytes,
+          little-endian).
+
+  bt1_key1:
+    desc: >-
+      Key for a type-1 (raw-data chunk) B-tree node. Identifies the
+      logical position of a chunk in dataset space and records its
+      on-disk size.
+    fields:
+      chunk_size:
+        desc: "Size in bytes of the chunk payload as stored on disk (after any filter pipeline)."
+      filter_mask:
+        desc: >-
+          Pipeline skip mask. Bit i set means filter i was not applied
+          to this chunk (e.g. the chunk was already in the desired
+          form).
+      chunk_offsets:
+        desc: >-
+          Array of `global_bt1_ndims` uint64 logical dimension offsets
+          (0-based) locating the chunk in dataset space. The last entry
+          is always zero per the HDF5 specification and is used as a
+          sentinel.
+
+  bt1_pair0:
+    desc: >-
+      A single key/child pair for a type-0 (group) B-tree node. Each
+      valid body slot is one of these; a trailing key follows the last
+      pair.
+    fields:
+      key:
+        desc: "The `bt1_key0` key bounding the left edge of this child's range."
+      child_raw:
+        desc: >-
+          File address of the child (`sizeof_offsets` bytes). At
+          `node_level == 0` this points to a Symbol Table Node (SNOD);
+          at higher levels it points to another `v1_btree` node.
+
+  bt1_pair1:
+    desc: "A single key/child pair for a type-1 (raw-data chunk) B-tree node."
+    fields:
+      key:
+        desc: "The `bt1_key1` key identifying this chunk's logical position."
+      child_raw:
+        desc: >-
+          File address of the child (`sizeof_offsets` bytes). At
+          `node_level == 0` this is the file address of the chunk data
+          payload; at higher levels it is another `v1_btree` node.
+
+  v1_btree:
+    desc: >-
+      Version 1 B-tree node (signature 'TREE'). A single on-disk record
+      that acts as either an internal node or a leaf, depending on
+      `node_level`. Nodes at level 0 are leaves; their children are
+      either chunk data (type 1) or Symbol Table Nodes (type 0). A third
+      union arm `unknown` (six raw bytes) is a fallback for invalid node
+      types and is never written by a conforming implementation.
+    fields:
+      signature:
+        desc: "4-byte signature: 'T' 'R' 'E' 'E'. Must match exactly."
+      node_type:
+        desc: "Node type: 0 = group (symbol table), 1 = raw-data chunks."
+      node_level:
+        desc: >-
+          Height of this node in the tree. 0 = leaf; children at
+          level > 0 are also `v1_btree` nodes. The root node's level
+          equals the height of the tree minus one.
+      entries_used:
+        desc: >-
+          Number of valid key/child pairs stored in this node. Always
+          ≤ `2 × K` where K is the relevant superblock B-tree K value.
+      left_sib_raw:
+        desc: >-
+          File address of the left sibling node at the same tree level
+          (`sizeof_offsets` bytes). HADDR_UNDEF if this is the leftmost
+          node at this level.
+      right_sib_raw:
+        desc: >-
+          File address of the right sibling node at the same level.
+          HADDR_UNDEF if this is the rightmost node.
+    variants:
+      type0:
+        desc: "Node body for a type-0 (group symbol table) node."
+        fields:
+          pairs:
+            desc: "Array of `entries_used` `bt1_pair0` key/child pairs in ascending key order."
+          final_key:
+            desc: "Trailing `bt1_key0` key bounding the right edge of the last child's range."
+      type1:
+        desc: "Node body for a type-1 (raw-data chunk) node."
+        fields:
+          pairs:
+            desc: "Array of `entries_used` `bt1_pair1` key/child pairs in ascending chunk-offset order."
+          final_key:
+            desc: "Trailing `bt1_key1` key bounding the right edge of the last chunk."
+
+  snod_node:
+    desc: >-
+      Symbol Table Node (signature 'SNOD'). Leaf node pointed to by the
+      child pointers of a type-0 B-tree leaf. Each SNOD holds between
+      0 and `2 × stab_leaf_k` symbol table entries; `num_symbols`
+      records how many are valid. The `stab_ent` type is defined in
+      `superblock.pk`.
+    fields:
+      signature:
+        desc: "4-byte signature: 'S' 'N' 'O' 'D'. Must match exactly."
+      version:
+        desc: "Symbol table node version. Must be 1."
+      res:
+        desc: "Reserved. Must be zero."
+      num_symbols:
+        desc: "Number of valid `stab_ent` entries in `entries`."
+      entries:
+        desc: >-
+          Array of `num_symbols` symbol table entries of type `stab_ent`
+          (see `superblock.pk`). Each entry records a link name offset,
+          an object header address, a cache type, and a scratch-pad area.

--- a/docs/spec/v2_btree.yml
+++ b/docs/spec/v2_btree.yml
@@ -1,0 +1,340 @@
+pickle: v2_btree.pk
+section: "III.A.2. Disk Format: Level 1B – Version 2 B-tree Nodes"
+intro: |
+  Version 2 B-trees are a self-describing, checksummed replacement for
+  the version 1 B-tree used for new indexing needs introduced in HDF5
+  1.8. Three on-disk structures are defined:
+
+  - **Header** (signature 'BTHD') — one per B-tree; records the record
+    type, node geometry, depth, and root node address.
+  - **Leaf node** (signature 'BTLF') — stores up to the configured
+    maximum records with no child pointers.
+  - **Internal node** (signature 'BTIN') — stores records interleaved
+    with child pointers, each carrying the record count of the child
+    node and, for nodes deeper than level 1, the total record count of
+    the child's subtree.
+
+  Eleven record types are defined, covering: huge-object tracking
+  (types 1–4), indexed-group link names (types 5–6), shared object
+  header messages (type 7), indexed-attribute names and creation order
+  (types 8–9), and non-filtered and filtered dataset chunk addresses
+  (types 10–11).
+
+  The global variables `global_bt2_*` must be set correctly before
+  mapping any node. `print_v2_btree(addr#B)` handles this automatically
+  by reading the header first.
+
+types:
+
+  # ── Header ─────────────────────────────────────────────────────────────────
+
+  v2_btree_hdr:
+    desc: >-
+      Version 2 B-tree header (signature 'BTHD'). Describes the geometry
+      of the entire B-tree. Mapping this struct sets the global parameters
+      `global_bt2_type`, `global_bt2_record_size`, `global_bt2_node_size`,
+      and `global_bt2_depth` via constraint side-effects, so subsequent
+      node mappings require no additional setter calls.
+    fields:
+      signature:
+        desc: "4-byte signature: 'B' 'T' 'H' 'D'. Must match exactly."
+      version:
+        desc: "Header format version. Must be 0."
+      record_type:
+        desc: "Record type identifier (1–11). Determines which `bt2_rec_type*` struct to use for records."
+      node_size:
+        desc: "Size in bytes of each B-tree node (leaf or internal). All nodes have the same size."
+      record_size:
+        desc: "Size in bytes of each record within a node."
+      depth:
+        desc: "Tree depth. 0 means the root is a leaf node; > 0 means the root is an internal node."
+      split_percent:
+        desc: "Node occupancy percentage above which a node is split (typically 100)."
+      merge_percent:
+        desc: "Node occupancy percentage below which two sibling nodes are merged (typically 40)."
+      root_addr_raw:
+        desc: "File address of the root node (`sizeof_offsets` bytes)."
+      num_root_records:
+        desc: "Number of records currently stored in the root node."
+      total_nrec_raw:
+        desc: "Total number of records across all nodes in the B-tree (`sizeof_lengths` bytes)."
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding header bytes."
+
+  # ── Record types 1–4: huge objects ─────────────────────────────────────────
+
+  bt2_rec_type1:
+    desc: >-
+      Record type 1 — indirectly accessed, non-filtered huge object.
+      The object is tracked in the fractal heap and carries a unique
+      object ID.
+    fields:
+      huge_obj_addr_raw:
+        desc: "File address of the huge object (`sizeof_offsets` bytes)."
+      huge_obj_len_raw:
+        desc: "Size in bytes of the huge object (`sizeof_lengths` bytes)."
+      huge_obj_id_raw:
+        desc: "Unique huge-object ID assigned by the heap (`sizeof_lengths` bytes)."
+
+  bt2_rec_type2:
+    desc: >-
+      Record type 2 — indirectly accessed, filtered huge object. Like
+      type 1 but the data has passed through the filter pipeline; carries
+      the unfiltered size and a filter skip mask.
+    fields:
+      huge_obj_addr_raw:
+        desc: "File address of the filtered huge object (`sizeof_offsets` bytes)."
+      huge_obj_len_raw:
+        desc: "On-disk (filtered) size in bytes (`sizeof_lengths` bytes)."
+      filter_mask:
+        desc: "Filter pipeline skip mask (same semantics as `bt1_key1.filter_mask`)."
+      huge_obj_mem_size_raw:
+        desc: "Unfiltered (in-memory) size in bytes (`sizeof_lengths` bytes)."
+      huge_obj_id_raw:
+        desc: "Unique huge-object ID (`sizeof_lengths` bytes)."
+
+  bt2_rec_type3:
+    desc: >-
+      Record type 3 — directly accessed, non-filtered huge object. The
+      object is accessed by file address without heap tracking, so there
+      is no unique ID field.
+    fields:
+      huge_obj_addr_raw:
+        desc: "File address of the huge object (`sizeof_offsets` bytes)."
+      huge_obj_len_raw:
+        desc: "Size in bytes of the huge object (`sizeof_lengths` bytes)."
+
+  bt2_rec_type4:
+    desc: >-
+      Record type 4 — directly accessed, filtered huge object. Like type
+      3 but includes filter metadata; no unique ID field.
+    fields:
+      huge_obj_addr_raw:
+        desc: "File address of the filtered huge object (`sizeof_offsets` bytes)."
+      huge_obj_len_raw:
+        desc: "On-disk (filtered) size in bytes (`sizeof_lengths` bytes)."
+      filter_mask:
+        desc: "Filter pipeline skip mask."
+      huge_obj_mem_size_raw:
+        desc: "Unfiltered (in-memory) size in bytes (`sizeof_lengths` bytes)."
+
+  # ── Record types 5–6: indexed-group link names ─────────────────────────────
+
+  bt2_rec_type5:
+    desc: >-
+      Record type 5 — link name in a creation-name-ordered indexed group.
+      Provides fast lookup of a link by the hash of its name.
+    fields:
+      name_hash:
+        desc: "Jenkins lookup3 hash of the link name (used as the B-tree key)."
+      heap_id_raw:
+        desc: "7-byte fractal heap object ID for the link record."
+
+  bt2_rec_type6:
+    desc: >-
+      Record type 6 — link name in a creation-order-indexed group.
+      Provides fast lookup of a link by its creation order value.
+    fields:
+      creation_order:
+        desc: "Link creation order value (B-tree key)."
+      heap_id_raw:
+        desc: "7-byte fractal heap object ID for the link record."
+
+  # ── Record type 7: shared object header messages ────────────────────────────
+
+  bt2_rec_type7_sub0:
+    desc: >-
+      Record type 7, sub-type 0 — shared message stored in the fractal
+      heap. Identified at runtime by reading the first byte of the record:
+      `message_location == 0` selects this sub-type.
+    fields:
+      message_location:
+        desc: "Storage location indicator. Must be 0 for this sub-type (message is in the fractal heap)."
+      hash:
+        desc: "Jenkins lookup3 hash of the shared message payload (B-tree key)."
+      reference_count:
+        desc: "Number of object headers that reference this shared message."
+      heap_id_raw:
+        desc: "8-byte fractal heap object ID for the shared message."
+
+  bt2_rec_type7_sub1:
+    desc: >-
+      Record type 7, sub-type 1 — shared message stored inline in an
+      object header. Identified by `message_location == 1`.
+    fields:
+      message_location:
+        desc: "Storage location indicator. Must be 1 for this sub-type (message is in an object header)."
+      hash:
+        desc: "Jenkins lookup3 hash of the shared message payload (B-tree key)."
+      message_type:
+        desc: "Object header message type of the shared message."
+      obj_hdr_index:
+        desc: "Index of the message within its containing object header."
+      obj_hdr_addr_raw:
+        desc: "File address of the object header containing the shared message (`sizeof_offsets` bytes)."
+
+  # ── Record types 8–9: indexed attributes ───────────────────────────────────
+
+  bt2_rec_type8:
+    desc: >-
+      Record type 8 — attribute name for name-ordered indexed attributes.
+      Provides fast lookup of an attribute by name hash and creation order.
+    fields:
+      heap_id_raw:
+        desc: "8-byte fractal heap object ID for the attribute record."
+      message_flags:
+        desc: "Object header message flags for this attribute (same bit definitions as `msg_prefix.msg_flags`)."
+      creation_order:
+        desc: "Attribute creation order value."
+      name_hash:
+        desc: "Jenkins lookup3 hash of the attribute name (primary B-tree key)."
+
+  bt2_rec_type9:
+    desc: >-
+      Record type 9 — attribute name for creation-order-indexed attributes.
+      Like type 8 but without the name hash; creation order is the key.
+    fields:
+      heap_id_raw:
+        desc: "8-byte fractal heap object ID for the attribute record."
+      message_flags:
+        desc: "Object header message flags for this attribute."
+      creation_order:
+        desc: "Attribute creation order value (B-tree key)."
+
+  # ── Record types 10–11: dataset chunk addresses ────────────────────────────
+
+  bt2_rec_type10:
+    desc: >-
+      Record type 10 — non-filtered dataset chunk address. Used as the
+      chunk index for datasets whose chunks pass through no filter
+      pipeline. The number of `scaled_offsets` entries equals the dataset
+      dimensionality; before mapping, set `global_bt2_ndims` accordingly
+      or call `print_v2_btree` which derives it automatically.
+    fields:
+      chunk_addr_raw:
+        desc: "File address of the chunk data payload (`sizeof_offsets` bytes)."
+      scaled_offsets:
+        desc: >-
+          Array of `global_bt2_ndims` uint64 scaled chunk position values.
+          Each entry is the logical dimension offset divided by the chunk
+          dimension size, giving the chunk's coordinates in chunk-index
+          space (B-tree key).
+
+  bt2_rec_type11:
+    desc: >-
+      Record type 11 — filtered dataset chunk address. Like type 10 but
+      includes the on-disk (filtered) chunk size and a filter skip mask.
+    fields:
+      chunk_addr_raw:
+        desc: "File address of the filtered chunk data payload (`sizeof_offsets` bytes)."
+      chunk_size_raw:
+        desc: "On-disk (filtered) chunk size in bytes (`sizeof_lengths` bytes)."
+      filter_mask:
+        desc: "Filter pipeline skip mask for this chunk."
+      scaled_offsets:
+        desc: "Array of `global_bt2_ndims` uint64 scaled chunk position values (B-tree key)."
+
+  # ── Fallback record ─────────────────────────────────────────────────────────
+
+  bt2_raw_record:
+    desc: >-
+      Generic fallback record used when the record type is unknown or
+      unhandled. Stores the raw bytes of the record so they can be
+      inspected without type-specific decoding.
+    fields:
+      data:
+        desc: "Raw record bytes (`global_bt2_record_size` bytes)."
+
+  # ── Child pointer sub-structures ───────────────────────────────────────────
+
+  bt2_child_ptr_d1:
+    desc: >-
+      Child pointer in a depth-1 internal node (one whose children are
+      leaf nodes). Contains the child's file address and the number of
+      records directly stored in that child. No subtree record count is
+      needed because the child is a leaf.
+    fields:
+      child_addr_raw:
+        desc: "File address of the child node (`sizeof_offsets` bytes)."
+      nrec_in_child_raw:
+        desc: >-
+          Number of records stored in the child node
+          (`global_bt2_nrec_in_node_bytes` bytes). Use
+          `set_bt2_nrec_size_from_hdr` to compute the correct byte
+          width from the header.
+
+  bt2_child_ptr_dn:
+    desc: >-
+      Child pointer in a depth > 1 internal node (one whose children
+      are themselves internal nodes). Adds a subtree record count field
+      that records the total number of records in the child's entire
+      subtree.
+    fields:
+      child_addr_raw:
+        desc: "File address of the child node (`sizeof_offsets` bytes)."
+      nrec_in_child_raw:
+        desc: "Number of records directly in the child node (`global_bt2_nrec_in_node_bytes` bytes)."
+      nrec_in_subtree_raw:
+        desc: >-
+          Total records in the child's subtree including all descendant
+          nodes (`global_bt2_nrec_in_subtree_bytes` bytes). Use
+          `set_bt2_nrec_subtree_size_from_hdr` to compute the correct
+          byte width.
+
+  # ── Leaf and internal nodes ─────────────────────────────────────────────────
+
+  v2_btree_leaf:
+    desc: >-
+      Version 2 B-tree leaf node (signature 'BTLF'). Contains up to the
+      configured maximum number of records and no child pointers. Before
+      mapping, set `global_bt2_nrec` to the record count for this node
+      (from `hdr.num_root_records` for the root, or from the parent's
+      `nrec_in_child_raw` for non-root nodes).
+    fields:
+      signature:
+        desc: "4-byte signature: 'B' 'T' 'L' 'F'. Must match exactly."
+      version:
+        desc: "Leaf node format version. Must be 0."
+      record_type:
+        desc: "Record type identifier (mirrors `v2_btree_hdr.record_type`)."
+      records:
+        desc: >-
+          Array of `global_bt2_nrec` raw records, each `global_bt2_record_size`
+          bytes. Use `print_v2_btree_record_at` to decode individual
+          records according to `record_type`.
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding node bytes."
+
+  v2_btree_internal:
+    desc: >-
+      Version 2 B-tree internal node (signature 'BTIN'). Stores records
+      interleaved with `global_bt2_nrec + 1` child pointers. The child-
+      pointer layout depends on the node's depth: depth-1 nodes use
+      `bt2_child_ptr_d1`; deeper nodes use `bt2_child_ptr_dn`. Before
+      mapping, set `global_bt2_depth` and `global_bt2_nrec` to the
+      values for this node.
+    fields:
+      signature:
+        desc: "4-byte signature: 'B' 'T' 'I' 'N'. Must match exactly."
+      version:
+        desc: "Internal node format version. Must be 0."
+      record_type:
+        desc: "Record type identifier (mirrors `v2_btree_hdr.record_type`)."
+      records:
+        desc: "Array of `global_bt2_nrec` raw records in ascending key order."
+      children:
+        desc: "Union of `global_bt2_nrec + 1` child pointers; layout selected by tree depth."
+      chksum:
+        desc: "Jenkins lookup3 checksum of all preceding node bytes."
+    variants:
+      d1:
+        desc: >-
+          Child-pointer array for a depth-1 internal node (children are
+          leaves). Each pointer is a `bt2_child_ptr_d1` carrying the
+          child address and record count only.
+      dn:
+        desc: >-
+          Child-pointer array for a depth > 1 internal node (children
+          are internal nodes). Each pointer is a `bt2_child_ptr_dn`
+          carrying the child address, node record count, and subtree
+          record count.

--- a/tools/pkdoc.py
+++ b/tools/pkdoc.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""pkdoc.py — generate or check specification Markdown from pickle prose sidecars.
+
+Usage:
+    python3 tools/pkdoc.py --doc docs/spec/superblock.yml
+    python3 tools/pkdoc.py --doc docs/spec/superblock.yml --check
+    python3 tools/pkdoc.py --doc docs/spec/superblock.yml --out /tmp/superblock.md
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML not installed.  Run: pip install pyyaml")
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def strip_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.DOTALL)
+    text = re.sub(r"//[^\n]*", "", text)
+    return text
+
+
+def find_matching_brace(text: str, start: int) -> int:
+    """Return the index one past the closing brace that matches the opening
+    brace assumed to be at position start-1 (depth already = 1 on entry)."""
+    depth = 1
+    i = start
+    while i < len(text) and depth > 0:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    return i
+
+
+# ── Poke type extractor (for --check) ────────────────────────────────────────
+
+def pk_top_level_types(pk_text: str) -> set[str]:
+    """Return the set of struct/union type names defined at file scope."""
+    return set(re.findall(r"\btype\s+(\w+)\s*=\s*(?:struct|union)", pk_text))
+
+
+def pk_type_span(pk_text: str, type_name: str) -> str | None:
+    """Return the full source text of the named type definition, or None."""
+    m = re.search(r"\btype\s+" + re.escape(type_name) + r"\s*=", pk_text)
+    if not m:
+        return None
+    open_pos = pk_text.find("{", m.end())
+    if open_pos < 0:
+        return None
+    close_pos = find_matching_brace(pk_text, open_pos + 1)
+    return pk_text[m.start() : close_pos]
+
+
+# ── YAML sidecar ─────────────────────────────────────────────────────────────
+
+def load_sidecar(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+def sidecar_names(type_info: dict) -> set[str]:
+    """Recursively collect every field/variant name documented for one type."""
+    names: set[str] = set()
+    for fname in (type_info.get("fields") or {}):
+        names.add(fname)
+    for vname, vinfo in (type_info.get("variants") or {}).items():
+        names.add(vname)
+        if isinstance(vinfo, dict):
+            names.update(sidecar_names(vinfo))
+    return names
+
+
+# ── Markdown renderer ─────────────────────────────────────────────────────────
+
+def field_table(fields: dict) -> str:
+    rows = ["| Field | Description |", "|-------|-------------|"]
+    for name, info in fields.items():
+        if isinstance(info, dict):
+            desc = (info.get("desc") or "").strip()
+            note = (info.get("note") or "").strip()
+            if note:
+                desc = f"{desc} _{note}_"
+        else:
+            desc = str(info).strip() if info else ""
+        rows.append(f"| `{name}` | {desc} |")
+    return "\n".join(rows)
+
+
+def render_type(name: str, type_yaml: dict, heading: str = "##") -> list[str]:
+    out: list[str] = []
+    out.append(f"{heading} `{name}`\n")
+    desc = (type_yaml.get("desc") or "").strip()
+    if desc:
+        out.append(f"{desc}\n")
+    fields = type_yaml.get("fields")
+    if fields:
+        out.append(field_table(fields))
+        out.append("")
+    for vname, vinfo in (type_yaml.get("variants") or {}).items():
+        if not isinstance(vinfo, dict):
+            vinfo = {"desc": str(vinfo) if vinfo else ""}
+        out.extend(render_type(vname, vinfo, heading=heading + "#"))
+    return out
+
+
+def render(doc: dict, out_path: Path) -> None:
+    lines: list[str] = []
+
+    section = doc.get("section", "")
+    if section:
+        lines.append(f"# {section}\n")
+
+    intro = (doc.get("intro") or "").strip()
+    if intro:
+        lines.append(intro)
+        lines.append("")
+
+    for type_name, type_info in (doc.get("types") or {}).items():
+        lines.extend(render_type(type_name, type_info))
+        lines.append("")
+
+    note = (doc.get("note") or "").strip()
+    if note:
+        lines.append(f"> **Note:** {note}")
+        lines.append("")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines) + "\n")
+    print(f"Written: {out_path}")
+
+
+# ── Checker ───────────────────────────────────────────────────────────────────
+
+def check(doc: dict, pk_path: Path) -> bool:
+    pk_text = strip_comments(pk_path.read_text())
+    pk_types = pk_top_level_types(pk_text)
+    yaml_types: dict = doc.get("types") or {}
+
+    issues: list[str] = []
+    warnings: list[str] = []
+
+    # Types in YAML but not in pickle (stale)
+    for tname in yaml_types:
+        if tname not in pk_types:
+            issues.append(f"YAML type '{tname}' not found in {pk_path.name}")
+
+    # Types in pickle but not in YAML (undocumented), minus the explicit skip list
+    skip = set(doc.get("skip_types") or [])
+    for tname in sorted(pk_types - set(yaml_types) - skip):
+        warnings.append(f"pickle type '{tname}' is not documented in the sidecar")
+
+    # Field/variant names: every name in YAML must appear in the pickle type span
+    for tname, type_info in yaml_types.items():
+        span = pk_type_span(pk_text, tname)
+        if span is None:
+            continue  # already reported above
+        for name in sorted(sidecar_names(type_info)):
+            if not re.search(r"\b" + re.escape(name) + r"\b", span):
+                issues.append(
+                    f"'{tname}.{name}' documented in YAML but not found in pickle"
+                )
+
+    for w in warnings:
+        print(f"WARNING: {w}")
+    if issues:
+        print(f"CHECK FAILED ({pk_path.name}):")
+        for issue in issues:
+            print(f"  {issue}")
+        return False
+
+    print(f"CHECK OK: {pk_path.name}")
+    return True
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Generate spec Markdown from a YAML sidecar, or check consistency."
+    )
+    ap.add_argument("--doc", required=True, metavar="SIDECAR.yml",
+                    help="path to the YAML prose sidecar")
+    ap.add_argument("--check", action="store_true",
+                    help="check YAML/pickle consistency instead of generating")
+    ap.add_argument("--out", metavar="FILE",
+                    help="output Markdown path (default: docs/generated/<stem>.md)")
+    args = ap.parse_args()
+
+    sidecar_path = Path(args.doc)
+    if not sidecar_path.exists():
+        sys.exit(f"sidecar not found: {sidecar_path}")
+
+    doc = load_sidecar(sidecar_path)
+
+    pickle_name = doc.get("pickle")
+    if not pickle_name:
+        sys.exit(f"{sidecar_path}: missing 'pickle:' key")
+
+    pk_path = Path("pickles") / pickle_name
+    if not pk_path.exists():
+        sys.exit(f"pickle not found: {pk_path}")
+
+    if args.check:
+        ok = check(doc, pk_path)
+        sys.exit(0 if ok else 1)
+
+    out_path = (
+        Path(args.out) if args.out
+        else Path("docs/generated") / (sidecar_path.stem + ".md")
+    )
+    render(doc, out_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added a file format specification documentation generator. "The pickles contain the bytes, and the YAML sidecars contain the prose." The `pkdoc.py` file fuses them together and generates Markdown files for human consumption. `pkdoc.py` can also verify that no fields go undocumented. 