### PR TITLE
Fixes filtered chunk B-tree record decoding, specifically record type 11

### DIFF
--- a/docs/generated/v2_btree.md
+++ b/docs/generated/v2_btree.md
@@ -169,14 +169,14 @@ Record type 10 — non-filtered dataset chunk address. Used as the chunk index f
 
 ## `bt2_rec_type11`
 
-Record type 11 — filtered dataset chunk address. Like type 10 but includes the on-disk (filtered) chunk size and a filter skip mask.
+Record type 11 — filtered dataset chunk address. Like type 10 but includes the on-disk (filtered) chunk size and a filter skip mask. HDF5 supplies layout context to the v2 B-tree callbacks; for layout version 4 the chunk-size field can be shorter than `sizeof_lengths`. Set `global_bt2_ndims` to the number of real dataset dimensions and `global_bt2_chunk_size_len` before mapping when that context is known.
 
 | Field | Description |
 |-------|-------------|
 | `chunk_addr_raw` | File address of the filtered chunk data payload (`sizeof_offsets` bytes). |
-| `chunk_size_raw` | On-disk (filtered) chunk size in bytes (`sizeof_lengths` bytes). |
+| `chunk_size_raw` | On-disk filtered chunk size, `global_bt2_chunk_size_len` bytes. |
 | `filter_mask` | Filter pipeline skip mask for this chunk. |
-| `scaled_offsets` | Array of `global_bt2_ndims` uint64 scaled chunk position values (B-tree key). |
+| `scaled_offsets` | Array of `global_bt2_ndims` uint64 scaled chunk position values for real dataset dimensions only. |
 
 
 ## `bt2_raw_record`
@@ -242,5 +242,4 @@ Child-pointer array for a depth-1 internal node (children are leaves). Each poin
 ### `dn`
 
 Child-pointer array for a depth > 1 internal node (children are internal nodes). Each pointer is a `bt2_child_ptr_dn` carrying the child address, node record count, and subtree record count.
-
 

--- a/docs/spec/v2_btree.yml
+++ b/docs/spec/v2_btree.yml
@@ -224,15 +224,19 @@ types:
     desc: >-
       Record type 11 — filtered dataset chunk address. Like type 10 but
       includes the on-disk (filtered) chunk size and a filter skip mask.
+      HDF5 supplies layout context to the v2 B-tree callbacks; for layout
+      version 4 the chunk-size field can be shorter than `sizeof_lengths`.
+      Set `global_bt2_ndims` to the number of real dataset dimensions and
+      `global_bt2_chunk_size_len` before mapping when that context is known.
     fields:
       chunk_addr_raw:
         desc: "File address of the filtered chunk data payload (`sizeof_offsets` bytes)."
       chunk_size_raw:
-        desc: "On-disk (filtered) chunk size in bytes (`sizeof_lengths` bytes)."
+        desc: "On-disk filtered chunk size, `global_bt2_chunk_size_len` bytes."
       filter_mask:
         desc: "Filter pipeline skip mask for this chunk."
       scaled_offsets:
-        desc: "Array of `global_bt2_ndims` uint64 scaled chunk position values (B-tree key)."
+        desc: "Array of `global_bt2_ndims` uint64 scaled chunk position values for real dataset dimensions only."
 
   # ── Fallback record ─────────────────────────────────────────────────────────
 

--- a/pickles/v2_btree.pk
+++ b/pickles/v2_btree.pk
@@ -142,6 +142,28 @@ fun set_bt2_chunk_size_len = (uint<8> n) void:
     global_bt2_chunk_size_len = n;
 };
 
+/* Derive and set the type-11 filtered chunk-size field width from the
+ * record size and the (externally supplied) dataset dimensionality.
+ *
+ * A type-11 record is under-determined by record_size alone: the
+ * chunk-size width and the dimension count share one equation, so ndims
+ * MUST be known from layout context.  An out-of-range result therefore
+ * means the supplied ndims is wrong or stale; we raise rather than map a
+ * misaligned record silently.                                          */
+fun set_bt2_chunk_size_len_from_hdr = (uint<16> record_size, uint<8> ndims) void:
+{
+    var csl = record_size
+              - (global_sizeof_offsets as uint<16>)
+              - 4UH
+              - ((ndims as uint<16>) * 8UH);
+    if (csl < 1UH || csl > (global_sizeof_lengths as uint<16>)) {
+        printf("v2_btree: type-11 chunk_size_len %u16d out of range [1,%u8d]; ndims=%u8d is likely wrong (pass the dataset rank).\n",
+               csl, global_sizeof_lengths, ndims);
+        raise E_inval;
+    }
+    set_bt2_chunk_size_len(csl as uint<8>);
+};
+
 fun set_bt2_nrec_in_node_bytes = (uint<8> sz) void:
 {
     global_bt2_nrec_in_node_bytes = sz;
@@ -690,16 +712,20 @@ fun print_recurse_v2_btree = (offset<uint<64>,B> off) void:
  * Maps the header at the given file offset, computes field-width globals,
  * then prints the full tree recursively.
  *
- * For chunk index B-trees (record type 10 or 11), the dataset
- * dimensionality is derived automatically from hdr.record_size:
- *   type 10: ndims = (record_size - sizeof_offsets) / 8
- *   type 11: ndims = (record_size - sizeof_offsets - sizeof_lengths - 4) / 8
+ * For chunk index B-trees (record type 10 or 11) the dataset
+ * dimensionality is needed to size the record.  Type 10 has a single
+ * unknown and is recovered from hdr.record_size automatically.  Type 11
+ * is under-determined (the chunk-size width and ndims share one
+ * equation), so pass the real dataset rank via the optional `ndims`
+ * argument; otherwise the value previously primed with set_bt2_ndims
+ * (default 1) is used and a mis-sized record is rejected loudly.
  *
  * Usage:
- *   print_v2_btree(<addr>#B);
+ *   print_v2_btree(<addr>#B);          // type 10, or type 11 with primed ndims
+ *   print_v2_btree(<addr>#B, 3UB);     // type 11, dataset rank = 3
  * ----------------------------------------------------------------------- */
 
-fun print_v2_btree = (offset<uint<64>,B> off) void:
+fun print_v2_btree = (offset<uint<64>,B> off, uint<8> ndims = 0UB) void:
 {
     var hdr = v2_btree_hdr @ off;
     /* Mapping hdr called set_v2btree_type/node_size/record_size/depth
@@ -708,15 +734,19 @@ fun print_v2_btree = (offset<uint<64>,B> off) void:
     set_bt2_nrec_size_from_hdr(hdr.node_size, hdr.record_size);
     set_bt2_nrec_subtree_size_from_hdr(hdr.node_size, hdr.record_size, hdr.depth);
     set_bt2_nrec(hdr.num_root_records);
-    /* Derive dimensionality from record_size for chunk index B-trees. */
-    if (hdr.record_type == 10UB)
-        set_bt2_ndims(((hdr.record_size as uint<16>)
-                       - (global_sizeof_offsets as uint<16>)) / 8UH as uint<8>);
-    else if (hdr.record_type == 11UB)
-        set_bt2_chunk_size_len(((hdr.record_size as uint<16>)
-                                - (global_sizeof_offsets as uint<16>)
-                                - 4UH
-                                - ((global_bt2_ndims as uint<16>) * 8UH)) as uint<8>);
+    /* Resolve dimensionality for chunk-index B-trees.  An explicit ndims
+     * argument always wins; type 10 can otherwise self-derive it. */
+    if (hdr.record_type == 10UB) {
+        if (ndims > 0UB)
+            set_bt2_ndims(ndims);
+        else
+            set_bt2_ndims(((hdr.record_size as uint<16>)
+                           - (global_sizeof_offsets as uint<16>)) / 8UH as uint<8>);
+    } else if (hdr.record_type == 11UB) {
+        if (ndims > 0UB)
+            set_bt2_ndims(ndims);
+        set_bt2_chunk_size_len_from_hdr(hdr.record_size, global_bt2_ndims);
+    }
     hdr._print;
     print_recurse_v2_btree(bytes_to_off(hdr.root_addr_raw));
 };

--- a/pickles/v2_btree.pk
+++ b/pickles/v2_btree.pk
@@ -90,6 +90,7 @@ var global_bt2_node_size   = 0U;    /* Size in bytes of each node               
 var global_bt2_depth       = 0UH;   /* B-tree depth (0 = root is a leaf)          */
 var global_bt2_nrec        = 0UH;   /* Records in the node being mapped           */
 var global_bt2_ndims       = 1UB;   /* Dataset chunk dimensions (types 10 / 11)     */
+var global_bt2_chunk_size_len = 8UB; /* Filtered chunk-size field bytes (type 11) */
 
 /* Bytes used for the "nrec in child node" sub-field of each child pointer
  * in an internal node.  Equals ceil(log256(max_records_per_node)).
@@ -134,6 +135,11 @@ fun set_bt2_nrec = (uint<16> n) void:
 fun set_bt2_ndims = (uint<8> n) void:
 {
     global_bt2_ndims = n;
+};
+
+fun set_bt2_chunk_size_len = (uint<8> n) void:
+{
+    global_bt2_chunk_size_len = n;
 };
 
 fun set_bt2_nrec_in_node_bytes = (uint<8> sz) void:
@@ -406,11 +412,14 @@ type bt2_rec_type10 = struct {
 
 /* Type 11 - Filtered dataset chunk index
  *
- * Like type 10 but with filter metadata.
- * chunk_size_raw length is global_sizeof_lengths bytes.                */
+ * Like type 10 but with filter metadata.  HDF5 passes layout context to
+ * the v2 B-tree class callbacks; for layout v4 records the chunk-size
+ * field can be shorter than global_sizeof_lengths.  Set
+ * global_bt2_ndims to the number of real dataset dimensions and
+ * global_bt2_chunk_size_len before mapping when that context is known.  */
 type bt2_rec_type11 = struct {
     byte[global_sizeof_offsets]    chunk_addr_raw;   /* Chunk data file address      */
-    byte[global_sizeof_lengths]    chunk_size_raw;   /* Chunk size after filtering   */
+    byte[global_bt2_chunk_size_len] chunk_size_raw;  /* Chunk size after filtering   */
     uint<32>                       filter_mask;      /* Bit i set -> filter i skipped */
     uint<64>[global_bt2_ndims]     scaled_offsets;   /* Scaled chunk position        */
 };
@@ -704,10 +713,10 @@ fun print_v2_btree = (offset<uint<64>,B> off) void:
         set_bt2_ndims(((hdr.record_size as uint<16>)
                        - (global_sizeof_offsets as uint<16>)) / 8UH as uint<8>);
     else if (hdr.record_type == 11UB)
-        set_bt2_ndims(((hdr.record_size as uint<16>)
-                       - (global_sizeof_offsets as uint<16>)
-                       - (global_sizeof_lengths as uint<16>)
-                       - 4UH) / 8UH as uint<8>);
+        set_bt2_chunk_size_len(((hdr.record_size as uint<16>)
+                                - (global_sizeof_offsets as uint<16>)
+                                - 4UH
+                                - ((global_bt2_ndims as uint<16>) * 8UH)) as uint<8>);
     hdr._print;
     print_recurse_v2_btree(bytes_to_off(hdr.root_addr_raw));
 };


### PR DESCRIPTION
Previously bt2_rec_type11 assumed:

  chunk_size_raw length == global_sizeof_lengths

  That is not always true. For HDF5 v2 B-tree filtered chunk records, HDF5 supplies layout-specific context to the
  B-tree class callbacks. In some layout v4 cases, the filtered chunk-size field can be shorter than the file’s
  global length-size.

  What changed:

  - Added global_bt2_chunk_size_len, defaulting to 8.
  - Added setter:

  set_bt2_chunk_size_len(n)

  - Changed type 11 from:

  byte[global_sizeof_lengths] chunk_size_raw;

  to:

  byte[global_bt2_chunk_size_len] chunk_size_raw;

  - Updated print_v2_btree for record type 11 to compute the chunk-size field length from the record size:

  chunk_size_len =
    record_size
    - sizeof_offsets
    - 4-byte filter_mask
    - 8 * global_bt2_ndims

  Why this matters: if the chunk-size field length is wrong, every following field is shifted, so filter_mask and
  scaled_offsets decode incorrectly.

  For manual use, type 11 now needs real coordinate dimensionality before mapping records:

  set_bt2_ndims(coord_ndims);
  print_v2_btree(addr#B);

  or set both values directly before mapping individual records:

  set_bt2_ndims(coord_ndims);
  set_bt2_chunk_size_len(size_len);
  var rec = bt2_rec_type11 @ rec_off;

  The paired docs/spec were updated to say type 11’s chunk_size_raw is controlled by global_bt2_chunk_size_len,
  not always sizeof_lengths.