### PR TITLE
Fix for issue #69:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,16 @@ if(POKE_EXECUTABLE)
         TIMEOUT 30
         ENVIRONMENT "POKE_LOAD_PATH=${CMAKE_CURRENT_SOURCE_DIR}/pickles"
     )
+    add_test(
+        NAME pickle_mdci_regression
+        COMMAND "${POKE_EXECUTABLE}" --quiet -L
+                "${CMAKE_CURRENT_SOURCE_DIR}/pickles/tests/unit_mdci.pk"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+    set_tests_properties(pickle_mdci_regression PROPERTIES
+        TIMEOUT 30
+        ENVIRONMENT "POKE_LOAD_PATH=${CMAKE_CURRENT_SOURCE_DIR}/pickles"
+    )
     message(STATUS "shared pickle regression tests enabled (poke: ${POKE_EXECUTABLE})")
 else()
     message(STATUS "shared pickle regression tests skipped (needs poke)")

--- a/pickles/h5_format_constants.pk
+++ b/pickles/h5_format_constants.pk
@@ -61,3 +61,6 @@ var H5_FORMAT_SMLI_SIGNATURE = [0x53UB, 0x4dUB, 0x4cUB, 0x49UB]; /* SMLI */
 /* Free-space manager signatures.  */
 var H5_FORMAT_FSHD_SIGNATURE = [0x46UB, 0x53UB, 0x48UB, 0x44UB]; /* FSHD */
 var H5_FORMAT_FSSE_SIGNATURE = [0x46UB, 0x53UB, 0x53UB, 0x45UB]; /* FSSE */
+
+/* Metadata cache image block signature.  */
+var H5_FORMAT_MDCI_SIGNATURE = [0x4dUB, 0x44UB, 0x43UB, 0x49UB]; /* MDCI */

--- a/pickles/mdci.pk
+++ b/pickles/mdci.pk
@@ -1,0 +1,230 @@
+/* mdci.pk - HDF5 Metadata Cache Image Block (section III.J, Level 1J).  */
+
+/* Copyright (C) 2026 The HDF Group.  */
+
+/* This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Covers:
+ *   - Metadata Cache Image Block (signature "MDCI", Section III.J,
+ *     Level 1J of the HDF5 format spec v4.0)
+ *
+ * The metadata cache image block is a serialized snapshot of the metadata
+ * cache taken at file close, written when cache-image generation is enabled
+ * for the file.  It lets the library reconstruct the cache directly from
+ * this block on the next open instead of reparsing the file's metadata.
+ * The block is named by the "Metadata Cache Image" object header message
+ * (MDCI_MSG_ID 0x0018, see `oh_msg_mdci` in ohdr_msgs.pk), which lives in
+ * the superblock extension and stores only the block's address and size --
+ * not the block itself.
+ *
+ * This pickle decodes the block's own container: its header, its entry
+ * records, and their fixed metadata (flush-dependency graph, LRU state,
+ * flush ring, file address/length).  Each entry's "Entry Image" is the
+ * byte-for-byte serialized cache client that would otherwise sit at the
+ * entry's own file address; this pickle does not decode that nested
+ * payload, since its format is the client's own on-disk structure (an
+ * object header, B-tree node, or other cached metadata), not part of the
+ * cache-image container format itself.
+ *
+ * Load order:
+ *   common.pk     <- bytes_to_u64_le, global_sizeof_offsets,
+ *                    global_sizeof_lengths, H5_FORMAT_MDCI_SIGNATURE
+ *   superblock.pk <- sets global_sizeof_offsets, global_sizeof_lengths
+ *   mdci.pk
+ *
+ * Quick start:
+ *   print_mdci(<block_addr>#B);
+ *     Maps and prints the cache image block: header, then every entry in
+ *     the order captured in the image (object 0 first, i.e. file order).
+ *
+ *   Reaching the block from its object-header message:
+ *     var msg = oh_msg_mdci @ <msg_off>;
+ *     print_mdci(bytes_to_off(msg.image_addr_raw));
+ *
+ *   OR -- manual step-by-step:
+ *     var blk = mdci_block @ <block_addr>#B;
+ *     blk._print;
+ *     blk.entries[0]._print;
+ *
+ * On-disk layout ("Layout: Metadata Cache Image Block"):
+ *   [sig:4]["MDCI"] [ver:1][flags:1]
+ *   [image_data_len:L][n_entries:4]
+ *   [entry #0][entry #1]...[entry #(n_entries-1)]
+ *   [chksum:4]
+ * where L = sizeof_lengths.  image_data_len is the total byte length of
+ * the whole block, including this header, every entry, and the trailing
+ * checksum; it is also the value stored as "Metadata Cache Image Block
+ * Size" in the referencing object-header message.  n_entries must be > 0.
+ *
+ * Header flags: bit 0 set means adaptive-cache-resize status information
+ * follows the entries (current libhdf5 never generates this, so bit 0 is
+ * always 0 in practice); bits 1-7 are reserved.
+ *
+ * Per-entry layout ("Layout: Image Entry"):
+ *   [type_id:1][flags:1][ring:1][age:1]
+ *   [fd_child_count:2][fd_dirty_child_count:2]
+ *   [fd_parent_count:2][lru_rank:4]
+ *   [entry_addr:O][entry_length:L]
+ *   [flush_dep_parent_addr:O]*fd_parent_count
+ *   [entry_image:entry_length bytes]
+ * where O = sizeof_offsets, L = sizeof_lengths.  The parent-address list is
+ * present only when entry flags bit 3 is set (fd_parent_count > 0 then);
+ * entry_image is always present and is exactly entry_length bytes.
+ *
+ * Entry flags: bit 0 dirty (not yet written when the image was taken);
+ * bit 1 the entry was on the cache's LRU list, and lru_rank gives its
+ * position there (closer to 0 = more recently used); when clear, lru_rank
+ * is -1 (stored as the all-ones sentinel, 0xffffffff); bit 2 the entry is a
+ * flush-dependency parent (fd_child_count/fd_dirty_child_count > 0); bit 3
+ * the entry is a flush-dependency child, so fd_parent_count parent
+ * addresses follow the fixed fields; bits 4-7 reserved.
+ *
+ * Ring values (flush-dependency ring; outer rings flush before inner ones):
+ *   1 = user data (datasets and groups) -- outermost, flushed first
+ *   2 = raw-data free-space manager
+ *   3 = metadata free-space manager
+ *   4 = superblock extension
+ *   5 = superblock -- innermost, flushed last
+ */
+
+/* ----------------------------------------------------------------------- *
+ * Flush-dependency parent address (one per entry with flags bit 3 set).
+ * ----------------------------------------------------------------------- */
+
+type mdci_parent_addr = struct {
+    byte[global_sizeof_offsets] addr_raw;
+};
+
+/* ----------------------------------------------------------------------- *
+ * Image Entry -- one metadata cache entry captured in the image.
+ * ----------------------------------------------------------------------- */
+
+type mdci_entry = struct {
+    byte     type_id;                  /* cache-client type (library-internal) */
+    byte     entry_flags;
+    byte     ring;
+    byte     age;                      /* file opens/closes since last access  */
+    uint<16> fd_child_count;
+    uint<16> fd_dirty_child_count;
+    uint<16> fd_parent_count;
+    uint<32> lru_rank_raw;             /* -1 (0xffffffff) unless flags bit 1   */
+    byte[global_sizeof_offsets] entry_addr_raw;
+    byte[global_sizeof_lengths] entry_length_raw;
+
+    var body_len = bytes_to_u64_le(entry_length_raw);
+
+    mdci_parent_addr[fd_parent_count] parents;
+    byte[body_len] entry_image;
+
+    method _print = void:
+    {
+        printf("mdci_entry {\n");
+        printf("  type_id=%u8d\n", type_id);
+        printf("  flags=0x%u8x", entry_flags);
+        if ((entry_flags & 0x01UB) != 0UB) printf(" DIRTY");
+        if ((entry_flags & 0x02UB) != 0UB) printf(" ON_LRU");
+        if ((entry_flags & 0x04UB) != 0UB) printf(" FLUSH_DEP_PARENT");
+        if ((entry_flags & 0x08UB) != 0UB) printf(" FLUSH_DEP_CHILD");
+        printf("\n");
+        printf("  ring=%u8d", ring);
+        if      (ring == 1UB) printf(" (user data)");
+        else if (ring == 2UB) printf(" (raw-data free-space manager)");
+        else if (ring == 3UB) printf(" (metadata free-space manager)");
+        else if (ring == 4UB) printf(" (superblock extension)");
+        else if (ring == 5UB) printf(" (superblock)");
+        else                  printf(" (unknown)");
+        printf("\n");
+        printf("  age=%u8d\n", age);
+        printf("  fd_child_count=%u16d\n", fd_child_count);
+        printf("  fd_dirty_child_count=%u16d\n", fd_dirty_child_count);
+        printf("  fd_parent_count=%u16d\n", fd_parent_count);
+        if ((entry_flags & 0x02UB) != 0UB)
+            printf("  lru_rank=%u32d\n", lru_rank_raw);
+        else
+            printf("  lru_rank=(not on LRU list)\n");
+        printf("  entry_addr=%u64d\n", bytes_to_u64_le(entry_addr_raw));
+        printf("  entry_length=%u64d\n", body_len);
+        var pi = 0UL;
+        while (pi < parents'length as uint<64>) {
+            printf("  flush_dep_parent[%u64d]=%u64d\n",
+                   pi, bytes_to_u64_le(parents[pi].addr_raw));
+            pi = pi + 1UL;
+        }
+        printf("  entry_image=%v\n", entry_image);
+        printf("}\n");
+    }
+};
+
+/* ----------------------------------------------------------------------- *
+ * Metadata Cache Image Block  (signature "MDCI")
+ *
+ * n_entries drives the declarative `entries` array directly, so mapping
+ * this type over a file whose declared count does not fit the available
+ * bytes raises the ordinary poke mapping exception for the entry that
+ * overruns -- callers exploring untrusted files should map it inside a
+ * `try`/`catch`, the same way h5explain guards other primitives whose
+ * declared size may be forged.  h5policy validates this block against the
+ * file's actual byte accounting independently, without using this type;
+ * see h5policy/pickles/h5_messages.pk.
+ * ----------------------------------------------------------------------- */
+
+type mdci_block = struct {
+    byte[4]  signature == H5_FORMAT_MDCI_SIGNATURE;
+    byte     version    == 0;
+    byte     flags;
+    byte[global_sizeof_lengths] image_data_len_raw;
+    uint<32> n_entries;
+
+    var entry_count = n_entries as uint<64>;
+
+    mdci_entry[entry_count] entries;
+
+    uint<32> chksum;
+
+    method _print = void:
+    {
+        printf("mdci_block {\n");
+        printf("  signature=%v\n", signature);
+        printf("  version=%u8d\n", version);
+        printf("  flags=0x%u8x", flags);
+        if ((flags & 0x01UB) != 0UB)
+            printf(" (adaptive-resize info follows)");
+        printf("\n");
+        printf("  image_data_len=%u64d\n", bytes_to_u64_le(image_data_len_raw));
+        printf("  n_entries=%u32d\n", n_entries);
+        var i = 0UL;
+        while (i < entries'length as uint<64>) {
+            printf("  entries[%u64d] = ", i);
+            entries[i]._print;
+            i = i + 1UL;
+        }
+        printf("  chksum=0x%u32x\n", chksum);
+        printf("}\n");
+    }
+};
+
+/* ----------------------------------------------------------------------- *
+ * print_mdci -- map and print the cache image block at OFF.
+ *
+ * Usage:
+ *   print_mdci(<block_addr>#B);
+ * ----------------------------------------------------------------------- */
+
+fun print_mdci = (offset<uint<64>,B> off) void:
+{
+    var blk = mdci_block @ off;
+    blk._print;
+};

--- a/pickles/tests/unit_mdci.pk
+++ b/pickles/tests/unit_mdci.pk
@@ -1,0 +1,209 @@
+/* unit_mdci.pk - Focused synthetic checks for the Metadata Cache Image
+   Block pickle.  Maps a small, hand-built block in memory and pins its
+   header fields, entry fields, flush-dependency parent list, and entry
+   image bytes.  */
+
+/* Copyright (C) 2026 The HDF Group.  */
+
+/* This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+load "common.pk";
+load "mdci.pk";
+
+var mdci_failures = 0;
+
+fun expect_mdci = (string name, int cond) void:
+{
+    if (cond)
+        printf("PASS %s\n", name);
+    else
+        {
+            printf("FAIL %s\n", name);
+            mdci_failures = mdci_failures + 1;
+        }
+}
+
+/* Keep the block compact while still exercising offset/length widths. */
+set_global_sizeof_offsets(4UB);
+set_global_sizeof_lengths(4UB);
+
+/* Four entries, chosen to walk every branch of mdci_entry._print /
+ * mdci_block._print, not just decode correct field values:
+ *   entry[0]: no flush-dependency parents, not on the LRU list, ring=1.
+ *   entry[1]: on the LRU list (rank 3) and a flush-dependency child of
+ *             one parent, whose address is entry[0]'s own file address.
+ *   entry[2]: dirty and a flush-dependency parent (ring=5), no parents
+ *             of its own -- exercises the DIRTY/FLUSH_DEP_PARENT flag
+ *             strings and the "superblock" ring name.
+ *   entry[3]: an unrecognized ring value -- exercises the "(unknown)"
+ *             ring branch.
+ * The block's own flags has bit 0 set, exercising the "adaptive-resize
+ * info follows" header branch (h5explain/h5policy never see this in a
+ * real file today, but the decoder must not choke on it).
+ *
+ * Block layout: 14-byte header, entries of 30+30+24+23 bytes, 4-byte
+ * checksum -- 14 + 30 + 30 + 24 + 23 + 4 = 125 bytes total.
+ */
+var entry0 =
+    [5UB, 0UB, 1UB, 0UB,                 /* type_id, flags, ring, age    */
+     0UB, 0UB,                            /* fd_child_count               */
+     0UB, 0UB,                            /* fd_dirty_child_count         */
+     0UB, 0UB,                            /* fd_parent_count              */
+     0xffUB, 0xffUB, 0xffUB, 0xffUB,      /* lru_rank: -1 (not on LRU)    */
+     0x00UB, 0x01UB, 0x00UB, 0x00UB,      /* entry_addr: 256              */
+     8UB, 0UB, 0UB, 0UB]                  /* entry_length: 8              */
+    + [0xaaUB, 0xbbUB, 0xccUB, 0xddUB,    /* entry_image (8 bytes)        */
+       0xeeUB, 0xffUB, 0x11UB, 0x22UB];
+
+var entry1 =
+    [9UB, 0x0aUB, 1UB, 2UB,               /* type_id, flags, ring, age    */
+     0UB, 0UB,                            /* fd_child_count               */
+     0UB, 0UB,                            /* fd_dirty_child_count         */
+     1UB, 0UB,                            /* fd_parent_count: 1           */
+     3UB, 0UB, 0UB, 0UB,                  /* lru_rank: 3                  */
+     0x00UB, 0x02UB, 0x00UB, 0x00UB,      /* entry_addr: 512              */
+     4UB, 0UB, 0UB, 0UB]                  /* entry_length: 4              */
+    + [0x00UB, 0x01UB, 0x00UB, 0x00UB]    /* flush_dep_parent[0]: 256     */
+    + [0x01UB, 0x02UB, 0x03UB, 0x04UB];   /* entry_image (4 bytes)        */
+
+var entry2 =
+    [7UB, 0x05UB, 5UB, 1UB,               /* type_id, flags (DIRTY|FLUSH_DEP_PARENT), ring=5, age */
+     2UB, 0UB,                            /* fd_child_count: 2            */
+     1UB, 0UB,                            /* fd_dirty_child_count: 1      */
+     0UB, 0UB,                            /* fd_parent_count: 0           */
+     0xffUB, 0xffUB, 0xffUB, 0xffUB,      /* lru_rank: -1 (not on LRU)    */
+     0x00UB, 0x03UB, 0x00UB, 0x00UB,      /* entry_addr: 768              */
+     2UB, 0UB, 0UB, 0UB]                  /* entry_length: 2              */
+    + [0x55UB, 0x66UB];                   /* entry_image (2 bytes)        */
+
+var entry3 =
+    [11UB, 0UB, 9UB, 0UB,                 /* type_id, flags, ring=9 (unknown), age */
+     0UB, 0UB,                            /* fd_child_count               */
+     0UB, 0UB,                            /* fd_dirty_child_count         */
+     0UB, 0UB,                            /* fd_parent_count              */
+     0xffUB, 0xffUB, 0xffUB, 0xffUB,      /* lru_rank: -1 (not on LRU)    */
+     0x00UB, 0x04UB, 0x00UB, 0x00UB,      /* entry_addr: 1024             */
+     1UB, 0UB, 0UB, 0UB]                  /* entry_length: 1              */
+    + [0x7fUB];                           /* entry_image (1 byte)         */
+
+var mdci_blob =
+    ['M', 'D', 'C', 'I',                  /* signature                    */
+     0UB,                                  /* version                      */
+     0x01UB,                               /* flags: bit 0 set              */
+     125UB, 0UB, 0UB, 0UB,                /* image_data_len: 125           */
+     4UB, 0UB, 0UB, 0UB]                  /* n_entries: 4                  */
+    + entry0
+    + entry1
+    + entry2
+    + entry3
+    + [0xdeUB, 0xadUB, 0xbeUB, 0xefUB];   /* chksum (opaque to this pickle)*/
+
+var mdci_ios = open("*unit-mdci-block*");
+byte[mdci_blob'length] @ mdci_ios : 0#B = mdci_blob;
+var blk = mdci_block @ mdci_ios : 0#B;
+
+expect_mdci("block_byte_extent",
+            blk'size / #B == mdci_blob'length
+            && blk'size / #B == 125);
+expect_mdci("block_header_fields",
+            blk.flags == 0x01UB
+            && bytes_to_u64_le(blk.image_data_len_raw) == 125UL
+            && blk.n_entries == 4U
+            && blk.entries'length == 4);
+
+expect_mdci("entry0_no_dependencies",
+            blk.entries[0].type_id == 5UB
+            && blk.entries[0].ring == 1UB
+            && blk.entries[0].fd_parent_count == 0UH
+            && blk.entries[0].parents'length == 0
+            && bytes_to_u64_le(blk.entries[0].entry_addr_raw) == 256UL
+            && bytes_to_u64_le(blk.entries[0].entry_length_raw) == 8UL
+            && blk.entries[0].entry_image'length == 8
+            && blk.entries[0].entry_image[0] == 0xaaUB
+            && blk.entries[0].entry_image[7] == 0x22UB);
+
+expect_mdci("entry1_on_lru_with_one_parent",
+            blk.entries[1].type_id == 9UB
+            && blk.entries[1].entry_flags == 0x0aUB
+            && blk.entries[1].age == 2UB
+            && blk.entries[1].fd_parent_count == 1UH
+            && blk.entries[1].parents'length == 1
+            && bytes_to_u64_le(blk.entries[1].parents[0].addr_raw) == 256UL
+            && blk.entries[1].lru_rank_raw == 3U
+            && bytes_to_u64_le(blk.entries[1].entry_addr_raw) == 512UL
+            && blk.entries[1].entry_image'length == 4
+            && blk.entries[1].entry_image[3] == 0x04UB);
+
+expect_mdci("entry2_dirty_and_flush_dep_parent",
+            blk.entries[2].type_id == 7UB
+            && blk.entries[2].entry_flags == 0x05UB
+            && blk.entries[2].ring == 5UB
+            && blk.entries[2].fd_child_count == 2UH
+            && blk.entries[2].fd_dirty_child_count == 1UH
+            && blk.entries[2].fd_parent_count == 0UH
+            && blk.entries[2].parents'length == 0
+            && bytes_to_u64_le(blk.entries[2].entry_addr_raw) == 768UL
+            && blk.entries[2].entry_image'length == 2
+            && blk.entries[2].entry_image[0] == 0x55UB
+            && blk.entries[2].entry_image[1] == 0x66UB);
+
+expect_mdci("entry3_unrecognized_ring",
+            blk.entries[3].type_id == 11UB
+            && blk.entries[3].entry_flags == 0UB
+            && blk.entries[3].ring == 9UB
+            && bytes_to_u64_le(blk.entries[3].entry_addr_raw) == 1024UL
+            && blk.entries[3].entry_image'length == 1
+            && blk.entries[3].entry_image[0] == 0x7fUB);
+
+expect_mdci("checksum_decoded_as_stored",
+            (blk.chksum as uint<64>) == 0xefbeaddeUL);
+
+/* _print walks every entry and branches on ring/flags; nothing above calls
+   it, so a wrong field name, a format-specifier/type mismatch, or an
+   off-by-one in the parent-list loop would pass every check above and still
+   crash here.  This proves the print paths run to completion (not that
+   their text is exactly right -- no pickle in this repo asserts on
+   printf'd text; format() exists but nothing here uses it for that). */
+var print_ok = 1;
+try {
+    blk._print;
+    blk.entries[0]._print;
+    blk.entries[1]._print;
+    blk.entries[2]._print;
+    blk.entries[3]._print;
+} catch (Exception e) {
+    print_ok = 0;
+}
+expect_mdci("print_methods_do_not_raise", print_ok);
+
+var saved_ios = get_ios();
+set_ios(mdci_ios);
+var print_mdci_ok = 1;
+try {
+    print_mdci(0#B);
+} catch (Exception e) {
+    print_mdci_ok = 0;
+}
+set_ios(saved_ios);
+expect_mdci("print_mdci_function_does_not_raise", print_mdci_ok);
+
+close(mdci_ios);
+
+if (mdci_failures != 0)
+    {
+        printf("UNIT MDCI: %i32d failure(s)\n", mdci_failures);
+        exit(1);
+    }
+printf("UNIT MDCI: all passed\n");


### PR DESCRIPTION
1) Add mdci.pk: HDF5 Metadata Cache Image Block pickle according to format spec section III.J, Level 1J
2) Add H5_FORMAT_MDCI_SIGNATURE to h5_format_constants.pk 3) Add pickles/tests/unit_mdci.pk
4) h5explain does not yet expose this pickle -- navigating to a cache image block or its referencing object-header message still falls through to raw/generic handling.  That integration needs to be followed up with another PR.