### PR TITLE
Fix for issue #41:

### DIFF
--- a/pickles/construct.pk
+++ b/pickles/construct.pk
@@ -75,25 +75,11 @@ type ohdr_v2 =
     byte[_chunk0_num_bytes] chunk0_size;
 
     var _chunk0_size = bytes_to_u64_le(chunk0_size);
+    /* msg_chunk already spans messages plus any trailing gap padding --
+       chunk0_size covers both -- so a caller wanting a gap simply includes
+       those bytes in msg_chunk itself; a separate gap field here would
+       double-count them and push chksum too far into the file. */
     byte[_chunk0_size] msg_chunk;
 
-    var crt_order_tracked = (flags & 4U) != 0;
-    fun get_gap_size = uint<64>:
-    {
-      var i = 0, _gap_size = 0;
-      var prefix_bytes = (crt_order_tracked) ? (V2_PREFIX_BYTES + 2) : V2_PREFIX_BYTES;
-
-      while (i + prefix_bytes <= _chunk0_size)
-        {
-          var sz = [msg_chunk[i + 2], msg_chunk[i + 1]] as uint<16>;
-          i = i + sz + prefix_bytes;
-        }
-
-      _gap_size = _chunk0_size - i;
-      return _gap_size;
-    }
-
-    var gap_size = get_gap_size();
-    byte[gap_size] gap if (gap_size > 0);
     uint<32> chksum;
   };

--- a/pickles/ohdr_msgs.pk
+++ b/pickles/ohdr_msgs.pk
@@ -2566,7 +2566,14 @@ type oh_hdr =
         
                 var crt_order_tracked = (flags & 4U) != 0;
 
-                /* Function to retrieve gap size */
+                /* Function to retrieve gap size.  msg_chunk (above) already
+                   spans messages + gap -- _chunk0_size covers both, per this
+                   function's own leftover-bytes computation -- so the gap
+                   bytes are the trailing gap_size bytes of msg_chunk itself,
+                   not additional bytes past it.  Mapping a separate `gap`
+                   field here would double-count them and push chksum
+                   gap_size bytes too far into the file; call this on demand
+                   (e.g. from a _print method) instead of mapping a field. */
                 fun get_gap_size = uint<64>:
                 {
                     var i = 0, _gap_size = 0;
@@ -2581,10 +2588,31 @@ type oh_hdr =
                     return _gap_size;
                 }
 
-                var gap_size = get_gap_size();
-
-                byte[gap_size] gap if (gap_size > 0);
                 byte[4] chksum;
+
+                method print_indented = (int depth) void:
+                {
+                    printf("struct {\n");
+                    indent(depth); printf("  signature=%v,\n", signature);
+                    indent(depth); printf("  version=%u8d,\n", version);
+                    indent(depth); printf("  flags=0x%u8x,\n", flags);
+                    if (flags & 1 <<. 5) {
+                        indent(depth); printf("  timestamps=%v,\n", timestamps);
+                    }
+                    if (flags & 1 <<. 4) {
+                        indent(depth); printf("  attr_phase=%v,\n", attr_phase);
+                    }
+                    indent(depth); printf("  chunk0_size=%v,\n", chunk0_size);
+                    indent(depth); printf("  _msg_chunk="); _msg_chunk._print; printf(",\n");
+                    indent(depth); printf("  gap_size=%u64d,\n", get_gap_size);
+                    indent(depth); printf("  chksum=%v\n", chksum);
+                    indent(depth); printf("}\n");
+                }
+
+                method _print = void:
+                {
+                    print_indented(2);
+                }
 
             } v2: sig_peek == H5_FORMAT_OHDR_SIGNATURE;
 


### PR DESCRIPTION
1) In ohdr_msgs.pk, remove the v2 object header's double-counting gap field 
2) Add a _print method to the v2 struct so all its fields including gap_size will be printed. 
3) Apply the same fix to construct.pk's ohdr_v2 builder type, which had the identical 
double-counting pattern on the write side